### PR TITLE
Fix ahead printing when both ahead and behind

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -127,7 +127,7 @@ function __bobthefish_git_ahead -d 'Print the ahead/behind state for the current
     return
   end
 
-  command git rev-list --left-right '@{upstream}...HEAD' ^/dev/null | awk '/>/ {a += 1} /</ {b += 1} {if (a > 0) nextfile} END {if (a > 0 && b > 0) print "±"; else if (a > 0) print "+"; else if (b > 0) print "-"}'
+  command git rev-list --left-right '@{upstream}...HEAD' ^/dev/null | awk '/>/ {a += 1} /</ {b += 1} {if (a > 0 && b > 0) nextfile} END {if (a > 0 && b > 0) print "±"; else if (a > 0) print "+"; else if (b > 0) print "-"}'
 end
 
 function __bobthefish_git_ahead_verbose -d 'Print a more verbose ahead/behind state for the current branch'


### PR DESCRIPTION
Specifically, the awk parsing bails out early if we're ahead, even though there may be later behind commits, resulting in a status of just "+" when "±" would be correct.

I believe the awk nextfile is an optimization to stop parsing early, so I left it in, but only if we already have both a > 0 and b > 0, in which case the printed status can't change.