### PR TITLE
Meet Vagrant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can override some of the following default options in your `config.fish`:
 set -g theme_display_git no
 set -g theme_display_git_untracked no
 set -g theme_display_git_ahead_verbose yes
+set -g theme_display_vagrant yes
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
 set -g theme_display_ruby no
@@ -83,6 +84,7 @@ set -g default_user your_normal_user
 
 **Prompt options**
 - `theme_display_ruby`. Use `no` to completely hide all information about Ruby version. By default Ruby version displayed if there is the difference from default settings.
+- `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note, only VirtualBox provider is supported.
 
 [fish]:       https://github.com/fish-shell/fish-shell
 [screenshot]: http://i.0x7f.us/bobthefish.png

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -252,7 +252,7 @@ function __bobthefish_prompt_vagrant -d 'Display Vagrant status'
       set -l __vm_status (VBoxManage showvminfo --machinereadable $i 2>/dev/null | grep 'VMState=' | tr -d '"' | cut -d '=' -f 2)
       set __vagrant_statuses "$__vagrant_statuses<$__vm_status>"
     end
-    # Transform statuses to gliphs
+    # Transform statuses to glyphs
     set __vagrant_statuses ( echo -n $__vagrant_statuses | sed \
       -e "s#<running>#$__bobthefish_vagrant_running_glyph#g" \
       -e "s#<poweroff>#$__bobthefish_vagrant_poweroff_glyph#g" \


### PR DESCRIPTION
Hi, I've made some experiments with [Vagrant](https://www.vagrantup.com/) support.
These bits are aimed to display the status of Vagrant virtual machine, which is associated with a current folder.
Picture show how is works:
![2015-12-16 15 08 12](https://cloud.githubusercontent.com/assets/156709/11839448/d3b83da2-a3fe-11e5-9b70-8a6594d3b9dd.png)
 
Since this tool requires Virtual Box (only supported hypervisor), this part of the prompt is *disabled*.
Detailed information about the meaning of signs is in code. I'm pretty sure it should be documented better…
Looking for feedback from you.
Thanks. 