### PR TITLE
Add show error code option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ set -g theme_title_use_abbreviated_path no
 set -g theme_date_format "+%a %H:%M"
 set -g theme_avoid_ambiguous_glyphs yes
 set -g theme_nerd_fonts yes
+set -g theme_show_exit_status yes
 set -g default_user your_normal_user
 ```
 
@@ -88,6 +89,7 @@ set -g default_user your_normal_user
 **Prompt options**
 - `theme_display_ruby`. Use `no` to completely hide all information about Ruby version. By default Ruby version displayed if there is the difference from default settings.
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
+- `theme_show_exit_status`. Set this option to yes to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 
 [fish]:       https://github.com/fish-shell/fish-shell
 [screenshot]: http://i.0x7f.us/bobthefish.png

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -29,8 +29,8 @@
 #     set -g theme_display_vi_hide_mode default
 #     set -g theme_avoid_ambiguous_glyphs yes
 #     set -g theme_nerd_fonts yes
+#     set -g theme_show_exit_status yes
 #     set -g default_user your_normal_user
-#     set -g show_error_code yes
 
 # ===========================
 # Helper methods
@@ -268,7 +268,7 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display symbols for a 
     __bobthefish_start_segment fff 000
     if [ "$nonzero" ]
       set_color $__bobthefish_med_red --bold
-      if [ "$show_error_code" = 'yes' ]
+      if [ "$theme_show_exit_status" = 'yes' ]
       	echo -n $last_status' '
       else
       	echo -n $__bobthefish_nonzero_exit_glyph

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -30,6 +30,7 @@
 #     set -g theme_avoid_ambiguous_glyphs yes
 #     set -g theme_nerd_fonts yes
 #     set -g default_user your_normal_user
+#     set -g show_error_code yes
 
 # ===========================
 # Helper methods
@@ -267,7 +268,11 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display symbols for a 
     __bobthefish_start_segment fff 000
     if [ "$nonzero" ]
       set_color $__bobthefish_med_red --bold
-      echo -n $__bobthefish_nonzero_exit_glyph
+      if [ "$show_error_code" = 'yes' ]
+      	echo -n $last_status' '
+      else
+      	echo -n $__bobthefish_nonzero_exit_glyph
+      end
     end
 
     if [ "$superuser" ]


### PR DESCRIPTION
I like my prompt to show the actual error code, so I added an option to show it. It can be toggled via the `$show_error_code` variable. The default is to just show an exclamation mark as before