### PR TITLE
Reset --bold as well after long long running command

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -19,6 +19,7 @@ function __bobthefish_cmd_duration -S -d 'Show command duration'
     echo -ns 'h '
   end
 
+  set_color $fish_color_normal
   set_color $fish_color_autosuggestion[1]
   echo -n $__bobthefish_left_arrow_glyph
 end


### PR DESCRIPTION
If this is not done the `--bold` flag is not reset and the command that is typed next will be bold as well:
![bold_command](https://cloud.githubusercontent.com/assets/1162278/14119168/266ef50a-f5ed-11e5-8045-85da73626ab9.png)
