### PR TITLE
Add option to disable git stash flagging

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -19,6 +19,7 @@
 #
 #     set -g theme_display_git no
 #     set -g theme_display_git_untracked no
+#     set -g theme_display_git_stashed no
 #     set -g theme_display_git_ahead_verbose yes
 #     set -g theme_git_worktree_support yes
 #     set -g theme_display_vagrant yes
@@ -382,8 +383,12 @@ end
 function __bobthefish_prompt_git -S -a current_dir -d 'Display the actual git state'
   set -l dirty   (command git diff --no-ext-diff --quiet --exit-code; or echo -n '*')
   set -l staged  (command git diff --cached --no-ext-diff --quiet --exit-code; or echo -n '~')
-  set -l stashed (command git rev-parse --verify --quiet refs/stash >/dev/null; and echo -n '$')
   set -l ahead   (__bobthefish_git_ahead)
+
+  set -l stashed ''
+  if [ "$theme_display_git_stashed" != 'no' ]
+    set stashed (command git rev-parse --verify --quiet refs/stash >/dev/null; and echo -n '$')
+  end
 
   set -l new ''
   set -l show_untracked (command git config --bool bash.showUntrackedFiles)


### PR DESCRIPTION
Adds the option requested in #37.

If you prefer not to add new options I understand, but this would fix my main annoyance with bobthefish so I'd love it if it could get in! :-)

As you can see I have used the same mechanism that you had used with the `$theme_display_git_untracked` option.

Any comments or changes you would like, let me know.