### PR TITLE
Add option to not use Powerline glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Be sure to have Oh My Fish installed. Then just:
 
     omf install bobthefish
 
-You will probably need a [Powerline-patched font][patching] for this to work.
+You will need a [Powerline-patched font][patching] for this to work, unless you enable the compatibility fallback option:
+
+    set -g theme_powerline_fonts no
+
 [I recommend picking one of these][fonts]. For more advanced awesome, install a [nerd fonts patched font][nerd-fonts], and enable nerd fonts support:
 
     set -g theme_nerd_fonts yes
@@ -76,6 +79,7 @@ set -g theme_title_display_path no
 set -g theme_title_use_abbreviated_path no
 set -g theme_date_format "+%a %H:%M"
 set -g theme_avoid_ambiguous_glyphs yes
+set -g theme_powerline_fonts no
 set -g theme_nerd_fonts yes
 set -g theme_show_exit_status yes
 set -g default_user your_normal_user

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -629,7 +629,7 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   set -l __bobthefish_left_arrow_glyph        \uE0B3
 
   if [ "$theme_powerline_fonts" = "no" ]
-    set __bobthefish_branch_glyph            ''
+    set __bobthefish_branch_glyph            '\u2387'
     set __bobthefish_ln_glyph                ''
     set __bobthefish_padlock_glyph           ''
     set __bobthefish_right_black_arrow_glyph ''

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -629,7 +629,7 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   set -l __bobthefish_left_arrow_glyph        \uE0B3
 
   if [ "$theme_powerline_fonts" = "no" ]
-    set __bobthefish_branch_glyph            '\u2387'
+    set __bobthefish_branch_glyph            \u2387
     set __bobthefish_ln_glyph                ''
     set __bobthefish_padlock_glyph           ''
     set __bobthefish_right_black_arrow_glyph ''

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -620,22 +620,22 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   set -l last_status $status
 
   # Powerline glyphs
-  set -l __bobthefish_branch_glyph            ''
-  set -l __bobthefish_ln_glyph                ''
-  set -l __bobthefish_padlock_glyph           ''
-  set -l __bobthefish_right_black_arrow_glyph ''
-  set -l __bobthefish_right_arrow_glyph       ''
-  set -l __bobthefish_left_black_arrow_glyph  ''
-  set -l __bobthefish_left_arrow_glyph        ''
+  set -l __bobthefish_branch_glyph            \uE0A0
+  set -l __bobthefish_ln_glyph                \uE0A1
+  set -l __bobthefish_padlock_glyph           \uE0A2
+  set -l __bobthefish_right_black_arrow_glyph \uE0B0
+  set -l __bobthefish_right_arrow_glyph       \uE0B1
+  set -l __bobthefish_left_black_arrow_glyph  \uE0B2
+  set -l __bobthefish_left_arrow_glyph        \uE0B3
 
-  if [ "$theme_powerline_fonts" != "no" ]
-    set __bobthefish_branch_glyph            \uE0A0
-    set __bobthefish_ln_glyph                \uE0A1
-    set __bobthefish_padlock_glyph           \uE0A2
-    set __bobthefish_right_black_arrow_glyph \uE0B0
-    set __bobthefish_right_arrow_glyph       \uE0B1
-    set __bobthefish_left_black_arrow_glyph  \uE0B2
-    set __bobthefish_left_arrow_glyph        \uE0B3
+  if [ "$theme_powerline_fonts" = "no" ]
+    set __bobthefish_branch_glyph            ''
+    set __bobthefish_ln_glyph                ''
+    set __bobthefish_padlock_glyph           ''
+    set __bobthefish_right_black_arrow_glyph ''
+    set __bobthefish_right_arrow_glyph       ''
+    set __bobthefish_left_black_arrow_glyph  ''
+    set __bobthefish_left_arrow_glyph        ''
   end
 
   # Additional glyphs

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -29,6 +29,7 @@
 #     set -g theme_display_vi yes
 #     set -g theme_display_vi_hide_mode default
 #     set -g theme_avoid_ambiguous_glyphs yes
+#     set -g theme_powerline_fonts no
 #     set -g theme_nerd_fonts yes
 #     set -g theme_show_exit_status yes
 #     set -g default_user your_normal_user
@@ -619,13 +620,23 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   set -l last_status $status
 
   # Powerline glyphs
-  set -l __bobthefish_branch_glyph            \uE0A0
-  set -l __bobthefish_ln_glyph                \uE0A1
-  set -l __bobthefish_padlock_glyph           \uE0A2
-  set -l __bobthefish_right_black_arrow_glyph \uE0B0
-  set -l __bobthefish_right_arrow_glyph       \uE0B1
-  set -l __bobthefish_left_black_arrow_glyph  \uE0B2
-  set -l __bobthefish_left_arrow_glyph        \uE0B3
+  set -l __bobthefish_branch_glyph            ''
+  set -l __bobthefish_ln_glyph                ''
+  set -l __bobthefish_padlock_glyph           ''
+  set -l __bobthefish_right_black_arrow_glyph ''
+  set -l __bobthefish_right_arrow_glyph       ''
+  set -l __bobthefish_left_black_arrow_glyph  ''
+  set -l __bobthefish_left_arrow_glyph        ''
+
+  if [ "$theme_powerline_fonts" != "no" ]
+    set __bobthefish_branch_glyph            \uE0A0
+    set __bobthefish_ln_glyph                \uE0A1
+    set __bobthefish_padlock_glyph           \uE0A2
+    set __bobthefish_right_black_arrow_glyph \uE0B0
+    set __bobthefish_right_arrow_glyph       \uE0B1
+    set __bobthefish_left_black_arrow_glyph  \uE0B2
+    set __bobthefish_left_arrow_glyph        \uE0B3
+  end
 
   # Additional glyphs
   set -l __bobthefish_detached_glyph          \u27A6

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -33,7 +33,10 @@ function __bobthefish_timestamp -S -d 'Show the current timestamp'
 end
 
 function fish_right_prompt -d 'bobthefish is all about the right prompt'
-  set -l __bobthefish_left_arrow_glyph \uE0B3
+  set -l __bobthefish_left_arrow_glyph '<'
+  if [ "$theme_powerline_fonts" != "no" ]
+    set __bobthefish_left_arrow_glyph \uE0B3
+  end
 
   set_color $fish_color_autosuggestion[1]
 

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -33,9 +33,9 @@ function __bobthefish_timestamp -S -d 'Show the current timestamp'
 end
 
 function fish_right_prompt -d 'bobthefish is all about the right prompt'
-  set -l __bobthefish_left_arrow_glyph '<'
-  if [ "$theme_powerline_fonts" != "no" ]
-    set __bobthefish_left_arrow_glyph \uE0B3
+  set -l __bobthefish_left_arrow_glyph \uE0B3
+  if [ "$theme_powerline_fonts" = "no" ]
+    set __bobthefish_left_arrow_glyph '<'
   end
 
   set_color $fish_color_autosuggestion[1]


### PR DESCRIPTION
Adds the option requested in #38.

Seems to be quite simple, though it's possible I've missed some.

I hope this will be accepted as it would be great for compatibility at very little cost.

Let me know if you'd like me to do anything differently.