### PR TITLE
Change colors for git staged and stashed statuses

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -404,10 +404,10 @@ function __bobthefish_prompt_git -S -a current_dir -d 'Display the actual git st
 
   set -l flag_bg $__bobthefish_lt_green
   set -l flag_fg $__bobthefish_dk_green
-  if [ "$dirty" -o "$staged" ]
+  if [ "$dirty" ]
     set flag_bg $__bobthefish_med_red
     set flag_fg fff
-  else if [ "$stashed" ]
+  else if [ "$staged" ]
     set flag_bg $__bobthefish_lt_orange
     set flag_fg $__bobthefish_dk_orange
   end


### PR DESCRIPTION
A new solution to issue #37, based on the discussion in pull request #41.
Keeps the indication of the existence of stashes with the `$` symbol, but doesn't change the colour.
Also adds an orange prompt for unstaged changes.

Looks like this:
![screen shot 2016-05-17 at 13 49 32](https://cloud.githubusercontent.com/assets/1566516/15340451/ff234502-1c5f-11e6-83ee-f48716420753.png)
