### PR TITLE
Support chruby ruby_version for show_ruby()

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -599,6 +599,8 @@ function __bobthefish_show_ruby -S -d 'Current Ruby (rvm/rbenv)'
       or set global_ruby_version system
 
     [ "$ruby_version" = "$global_ruby_version" ]; and return
+  else if type -q chruby
+    set ruby_version $RUBY_VERSION
   end
   [ -z "$ruby_version" ]; and return
   __bobthefish_start_segment $__bobthefish_ruby_red $__bobthefish_lt_grey --bold


### PR DESCRIPTION
I've switched to `chruby` (https://github.com/postmodern/chruby) from `rbenv` recently due to the difficulties rbenv shims tend to introduce when debugging ruby runtimes. It's quite a popular alternative so it seems like it would be worth supporting. 

(RUBY_VERSION is blank if chruby is using the system version)