### PR TITLE
Add configurable color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ set -g theme_powerline_fonts no
 set -g theme_nerd_fonts yes
 set -g theme_show_exit_status yes
 set -g default_user your_normal_user
+set -g theme_color_scheme dark
 ```
 
 **Title options**
@@ -96,6 +97,55 @@ set -g default_user your_normal_user
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
 - `theme_show_exit_status`. Set this option to yes to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
+
+**Color scheme options**
+
+You can use the function `__bobthefish_display_colors` to preview the prompts in
+the current theme.
+
+Set `theme_color_scheme` in a terminal session or in your fish startup files to
+one of the following options to change the prompt colors.
+
+- `dark`. The default bobthefish theme.
+- `light`. A lighter version of the default theme.
+- `solarized` (or `solarized-dark`), `solarized-light`. Dark and light variants
+  of Solarized.
+- `base16` (or `base16-dark`), `base16-light`. Dark and light variants of the
+  default Base16 theme.
+- `zenburn`. An adaptation of Zenburn.
+
+Some of these may not look right if your terminal does not support 24 bit color,
+in which case you can try one of the `terminal` schemes (below). However, if
+you're using Solarized, Base16 (default), or Zenburn in your terminal and the
+terminal *does* support 24 bit color, the built in schemes will look nicer.
+
+There are several scheme that use whichever colors you currently have loaded
+into your terminal. The advantage of using the schemes that fall through to the
+terminal colors is that they automatically adapt to something acceptable
+whenever you change the 16 colors in your terminal profile.
+- `terminal` (or `terminal-dark` or `terminal-dark-black`)
+- `terminal-dark-white`. Same as `terminal`, but use white as the foreground
+  color on top of colored segments (in case your colors are very dark).
+- `terminal-light` (or `terminal-light-white`)
+- `terminal-light-black`. Same as `terminal-light`, but use black as the
+  foreground color on top of colored segments (in case your colors are very
+  bright).
+
+For some terminal themes, like dark base16 themes, the path segments in the
+prompt will be indistinguishable from the background. In those cases, try one of
+the following variations; they are identical to the `terminal` schemes except
+for using bright black (`brgrey`) and dull white (`grey`) in the place of black
+and bright white.
+- `terminal2` (or `terminal2-dark` or `terminal2-dark-black`)
+- `terminal2-dark-white`
+- `terminal2-light` (or `terminal2-light-white`)
+- `terminal2-light-black`
+
+Finally, you can specify your very own color scheme by setting
+`theme_color_scheme` to `user`. In that case, you also need to define some
+variables to set the colors of the prompt. See the "Colors" section of
+`fish_prompt.fish` for details.
+
 
 [fish]:       https://github.com/fish-shell/fish-shell
 [screencast]: https://cloud.githubusercontent.com/assets/53660/15454890/5649a9a6-1ff9-11e6-9bab-ac1f9278f0cb.gif

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -608,15 +608,15 @@ end
 # ===========================
 
 function __bobthefish_display_colors -d 'Print example prompts using the current color scheme'
-  set -g __bobthefish_display_colors 1
+  set -g __bobthefish_display_colors
 end
 
 function __bobthefish_maybe_display_colors -S
-  if test -z $__bobthefish_display_colors
+  if not set -q __bobthefish_display_colors
     return
   end
 
-  set -g __bobthefish_display_colors
+  set -e __bobthefish_display_colors
 
   echo
   set_color normal

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -763,31 +763,41 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
       # Do not set any variables in this section.
 
       # If you want to create your own color scheme, set `theme_color_scheme` to
-      # `user` and define the following variables in your fish startup file. Use
-      # `__bobthefish_display_colors` to easily see what these variables are
-      # used for.
+      # `user` and define the `__color_*` variables listed below in your fish
+      # startup file (`$OMF_CONFIG/init.fish`, or similar).
 
       # The value for each variable is an argument to pass to `set_color -b`.
-      # See See the color schemes below for examples.
+      # You can copy the commented code below as a base for your custom colors.
+      # Use `__bobthefish_display_colors` at the command line to easily see what
+      # these variables are used for.
+
+      # See the built-in color schemes below for more examples.
+
+      # # Example bobthefish color scheme:
+      # set -g theme_color_scheme user
       #
-      # - `__color_initial_segment_exit`
-      # - `__color_initial_segment_su`
-      # - `__color_initial_segment_jobs`
-      # - `__color_path`
-      # - `__color_path_basename`
-      # - `__color_path_nowrite`
-      # - `__color_path_nowrite_basename`
-      # - `__color_repo`
-      # - `__color_repo_work_tree`
-      # - `__color_repo_dirty`
-      # - `__color_repo_staged`
-      # - `__color_vi_mode_default`
-      # - `__color_vi_mode_insert`
-      # - `__color_vi_mode_visual`
-      # - `__color_vagrant`
-      # - `__color_username`
-      # - `__color_rvm`
-      # - `__color_virtualfish`
+      # set -g __color_initial_segment_exit  ffffff ce000f --bold
+      # set -g __color_initial_segment_su    ffffff 189303 --bold
+      # set -g __color_initial_segment_jobs  ffffff 255e87 --bold
+      #
+      # set -g __color_path                  333333 999999
+      # set -g __color_path_basename         333333 ffffff --bold
+      # set -g __color_path_nowrite          660000 cc9999
+      # set -g __color_path_nowrite_basename 660000 cc9999 --bold
+      #
+      # set -g __color_repo                  addc10 0c4801
+      # set -g __color_repo_work_tree        addc10 ffffff --bold
+      # set -g __color_repo_dirty            ce000f ffffff
+      # set -g __color_repo_staged           f6b117 3a2a03
+      #
+      # set -g __color_vi_mode_default       999999 333333 --bold
+      # set -g __color_vi_mode_insert        189303 333333 --bold
+      # set -g __color_vi_mode_visual        f6b117 3a2a03 --bold
+      #
+      # set -g __color_vagrant               48b4fb ffffff --bold
+      # set -g __color_username              cccccc 255e87
+      # set -g __color_rvm                   af0000 cccccc --bold
+      # set -g __color_virtualfish           005faf cccccc --bold
 
     case 'terminal' 'terminal-dark*'
       set -l colorfg black


### PR DESCRIPTION
* Refactor fish_prompt.fish to use semantically named variables
  throughout the script rather than specific colors. Set those variables
  to various colors depending on the `theme_color_scheme` variable.

* Add the `__bobthefish_display_colors` function to easily test and
  preview different color schemes.

* Update documentation.

Fixes #7.