### PR TITLE
Docker machine display and conditional date

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ set -g theme_display_git_untracked no
 set -g theme_display_git_ahead_verbose yes
 set -g theme_git_worktree_support yes
 set -g theme_display_vagrant yes
+set -g theme_display_docker_machine no
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
 set -g theme_display_ruby no
 set -g theme_display_user yes
 set -g theme_display_vi yes
 set -g theme_display_vi_hide_mode default
+set -g theme_display_date no
 set -g theme_title_display_process yes
 set -g theme_title_display_path no
 set -g theme_title_use_abbreviated_path no

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -292,6 +292,14 @@ function __bobthefish_prompt_vagrant_vmware -S -d 'Display VMWare Vagrant status
   set_color normal
 end
 
+function __bobthefish_prompt_docker -S
+    if set -q DOCKER_MACHINE_NAME
+        __bobthefish_start_segment $__bobthefish_vagrant fff --bold
+        echo -ns $DOCKER_MACHINE_NAME ' '
+    end
+    set_color normal
+end
+
 function __bobthefish_prompt_status -S -a last_status -d 'Display symbols for a non zero exit status, root and background jobs'
   set -l nonzero
   set -l superuser
@@ -699,6 +707,7 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   __bobthefish_prompt_status $last_status
   __bobthefish_prompt_vi
   __bobthefish_prompt_vagrant
+  __bobthefish_prompt_docker
   __bobthefish_prompt_user
   __bobthefish_prompt_rubies
   __bobthefish_prompt_virtualfish

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -292,7 +292,7 @@ function __bobthefish_prompt_vagrant_vmware -S -d 'Display VMWare Vagrant status
   set_color normal
 end
 
-function __bobthefish_prompt_docker -S
+function __bobthefish_prompt_docker -S -d 'Show docker machine name'
     [ "$theme_display_docker_machine" = 'no' -o -z "$DOCKER_MACHINE_NAME" ]; and return
     __bobthefish_start_segment $__bobthefish_vagrant fff --bold
     echo -ns $DOCKER_MACHINE_NAME ' '

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -293,10 +293,9 @@ function __bobthefish_prompt_vagrant_vmware -S -d 'Display VMWare Vagrant status
 end
 
 function __bobthefish_prompt_docker -S
-    if set -q DOCKER_MACHINE_NAME
-        __bobthefish_start_segment $__bobthefish_vagrant fff --bold
-        echo -ns $DOCKER_MACHINE_NAME ' '
-    end
+    [ "$theme_display_docker_machine" = 'no' -o -z "$DOCKER_MACHINE_NAME" ]; and return
+    __bobthefish_start_segment $__bobthefish_vagrant fff --bold
+    echo -ns $DOCKER_MACHINE_NAME ' '
     set_color normal
 end
 

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -25,6 +25,7 @@ function __bobthefish_cmd_duration -S -d 'Show command duration'
 end
 
 function __bobthefish_timestamp -S -d 'Show the current timestamp'
+  [ "$theme_display_date" = "no" ]; and return
   set -q theme_date_format
     or set -l theme_date_format "+%c"
 
@@ -41,5 +42,6 @@ function fish_right_prompt -d 'bobthefish is all about the right prompt'
   set_color $fish_color_autosuggestion
 
   __bobthefish_cmd_duration
+  __bobthefish_timestamp
   set_color normal
 end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -41,6 +41,5 @@ function fish_right_prompt -d 'bobthefish is all about the right prompt'
   set_color $fish_color_autosuggestion
 
   __bobthefish_cmd_duration
-  __bobthefish_timestamp
   set_color normal
 end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -21,7 +21,6 @@ function __bobthefish_cmd_duration -S -d 'Show command duration'
 
   set_color $fish_color_normal
   set_color $fish_color_autosuggestion
-  echo -n $__bobthefish_left_arrow_glyph
 end
 
 function __bobthefish_timestamp -S -d 'Show the current timestamp'
@@ -29,6 +28,7 @@ function __bobthefish_timestamp -S -d 'Show the current timestamp'
   set -q theme_date_format
     or set -l theme_date_format "+%c"
 
+  echo -n $__bobthefish_left_arrow_glyph
   echo -n ' '
   date $theme_date_format
 end


### PR DESCRIPTION
I probably shouldn't have rolled this into one PR but those were things I tweaked and I figured I might as well clean it up a little and open a PR :)

What is does is add a switch to be able to switch off the date display:
```
set -g theme_display_date no
```

And it shows which docker machine you're talking to:
<img width="782" alt="screen shot 2016-06-07 at 08 44 36" src="https://cloud.githubusercontent.com/assets/65520/15849795/2227c938-2c8c-11e6-846f-da012f775636.png">
