### PR TITLE
Fix #52

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -536,17 +536,12 @@ function __bobthefish_prompt_vi -S -d 'Display vi mode'
 end
 
 function __bobthefish_virtualenv_python_version -S -d 'Get current python version'
-  set -l python_version (readlink (which python))
-  [ -z "$python_version" ]
-    and set python_version (which python)
-  switch (basename "$python_version")
-    case 'python' 'python2*'
-      echo $__bobthefish_superscript_glyph[2]
-    case 'python3*'
-      echo $__bobthefish_superscript_glyph[3]
-    case 'pypy*'
-      echo $__bobthefish_pypy_glyph
+  set -l python_version_out (python --version 2>&1)
+  set -l python_version (echo $python_version_out | grep --only-matching 'Python .' | grep --only-matching '.$')
+  if echo $python_version_out | grep -q 'PyPy'
+    echo $__bobthefish_pypy_glyph
   end
+  echo $__bobthefish_superscript_glyph[$python_version]
 end
 
 function __bobthefish_prompt_virtualfish -S -d "Display activated virtual environment (only for virtualfish, virtualenv's activate.fish changes prompt by itself)"


### PR DESCRIPTION
It's working with openSUSE 13.2, `pyenv`, `pypy`, Python's 2 and 3 versions (irrespective of an executable name).