### PR TITLE
Add variable to ignore certain folder for hg project search

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -757,9 +757,6 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   # Save the last status for later (do this before the `set` calls below)
   set -l last_status $status
 
-  # hg settings
-  set -l theme_hg_ignored_dirs $HOME
-
   # Powerline glyphs
   set -l __bobthefish_branch_glyph            \uE0A0
   set -l __bobthefish_right_black_arrow_glyph \uE0B0

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -24,6 +24,7 @@
 #     set -g theme_display_vagrant yes
 #     set -g theme_display_docker_machine no
 #     set -g theme_display_hg yes
+#     set -g theme_hg_ignored_dirs
 #     set -g theme_display_virtualenv no
 #     set -g theme_display_ruby no
 #     set -g theme_display_user yes
@@ -119,7 +120,8 @@ end
 function __bobthefish_hg_project_dir -S -d 'Print the current hg project base directory'
   [ "$theme_display_hg" = 'yes' ]; or return
   set -l d $PWD
-  while not [ $d = / ]
+  set stop_on_dirs / $theme_hg_ignored_dirs
+  while not contains $d $stop_on_dirs
     if [ -e $d/.hg ]
       command hg root --cwd "$d" ^/dev/null
       return
@@ -382,6 +384,8 @@ function __bobthefish_prompt_user -S -d 'Display actual user if different from $
 end
 
 function __bobthefish_prompt_hg -S -a current_dir -d 'Display the actual hg state'
+  set -x HGRCPATH ''  # Disable hg plugins
+  set -x HGPLAIN 1    # Ensure parsable output of hg
   set -l dirty (command hg stat; or echo -n '*')
 
   set -l flags "$dirty"
@@ -752,6 +756,9 @@ end
 function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   # Save the last status for later (do this before the `set` calls below)
   set -l last_status $status
+
+  # hg settings
+  set -l theme_hg_ignored_dirs $HOME
 
   # Powerline glyphs
   set -l __bobthefish_branch_glyph            \uE0A0


### PR DESCRIPTION
It's set to `$HOME` by default. Also I considered the recommendation about setting some mercurial environmental variables from this letter: https://www.mercurial-scm.org/pipermail/mercurial/2014-November/047687.html