### PR TITLE
Display superuser glyph when using fakeroot

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -383,7 +383,7 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display symbols for a 
     and set nonzero $__bobthefish_nonzero_exit_glyph
 
   # if superuser (uid == 0)
-  [ (id -u $USER) -eq 0 ]
+  [ (id -u) -eq 0 ]
     and set superuser $__bobthefish_superuser_glyph
 
   # Jobs display

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -404,7 +404,12 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display symbols for a 
 
     if [ "$superuser" ]
       set_color normal
-      set_color -b $__color_initial_segment_su
+      if [ -z "$FAKEROOTKEY" ]
+        set_color -b $__color_initial_segment_su
+      else
+        set_color -b $__color_initial_segment_exit
+      end
+
       echo -n $__bobthefish_superuser_glyph
     end
 


### PR DESCRIPTION
Using `id -u` displays the current active id instead of the actual real one. This means that the superuser glyph will be shown when using the `fakeroot` utility to simulate being root.
Though I don't know if it was an intented feature not to show it in such cases...