### PR TITLE
Moved Git chars to glyph variables

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -179,7 +179,7 @@ function __bobthefish_git_ahead -S -d 'Print the ahead/behind state for the curr
         set ahead 1
       case '<*'
         if [ $ahead -eq 1 ]
-          echo '±'
+          echo "$__bobthefish_git_plus_minus_glyph"
           return
         end
         set behind 1
@@ -187,9 +187,9 @@ function __bobthefish_git_ahead -S -d 'Print the ahead/behind state for the curr
   end
 
   if [ $ahead -eq 1 ]
-    echo '+'
+    echo "$__bobthefish_git_plus_glyph"
   else if [ $behind -eq 1 ]
-    echo '-'
+    echo "$__bobthefish_git_minus_glyph"
   end
 end
 
@@ -205,11 +205,11 @@ function __bobthefish_git_ahead_verbose -S -d 'Print a more verbose ahead/behind
     case '0 0' # equal to upstream
       return
     case '* 0' # ahead of upstream
-      echo "↑$ahead"
+      echo "$__bobthefish_git_ahead_glyph$ahead"
     case '0 *' # behind upstream
-      echo "↓$behind"
+      echo "$__bobthefish_git_behind_glyph$behind"
     case '*' # diverged from upstream
-      echo "↑$ahead↓$behind"
+      echo "$__bobthefish_git_ahead_glyph$ahead$__bobthefish_git_behind_glyph$behind"
   end
 end
 
@@ -466,9 +466,9 @@ function __bobthefish_prompt_hg -S -a current_dir -d 'Display the actual hg stat
 end
 
 function __bobthefish_prompt_git -S -a current_dir -d 'Display the actual git state'
-  set -l dirty   (command git diff --no-ext-diff --quiet --exit-code; or echo -n '*')
-  set -l staged  (command git diff --cached --no-ext-diff --quiet --exit-code; or echo -n '~')
-  set -l stashed (command git rev-parse --verify --quiet refs/stash >/dev/null; and echo -n '$')
+  set -l dirty   (command git diff --no-ext-diff --quiet --exit-code; or echo -n "$__bobthefish_git_dirty_glyph")
+  set -l staged  (command git diff --cached --no-ext-diff --quiet --exit-code; or echo -n "$__bobthefish_git_staged_glyph")
+  set -l stashed (command git rev-parse --verify --quiet refs/stash >/dev/null; and echo -n "$__bobthefish_git_stashed_glyph")
   set -l ahead   (__bobthefish_git_ahead)
 
   set -l new ''
@@ -476,11 +476,7 @@ function __bobthefish_prompt_git -S -a current_dir -d 'Display the actual git st
   if [ "$theme_display_git_untracked" != 'no' -a "$show_untracked" != 'false' ]
     set new (command git ls-files --other --exclude-standard --directory --no-empty-directory)
     if [ "$new" ]
-      if [ "$theme_avoid_ambiguous_glyphs" = 'yes' ]
-        set new '...'
-      else
-        set new '…'
-      end
+      set new "$__bobthefish_git_untracked_glyph"
     end
   end
 
@@ -840,6 +836,17 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
   set -l __bobthefish_vagrant_stopping_glyph  \u21E3 # ⇣ 'stopping'
   set -l __bobthefish_vagrant_unknown_glyph   '!'    # strange cases
 
+  # Git glyphs
+  set -l __bobthefish_git_dirty_glyph      '*'
+  set -l __bobthefish_git_staged_glyph     '~'
+  set -l __bobthefish_git_stashed_glyph    '$'
+  set -l __bobthefish_git_untracked_glyph  '…'
+  set -l __bobthefish_git_ahead_glyph      \u2191 # '↑'
+  set -l __bobthefish_git_behind_glyph     \u2193 # '↓'
+  set -l __bobthefish_git_plus_glyph       '+'
+  set -l __bobthefish_git_minus_glyph      '-'
+  set -l __bobthefish_git_plus_minus_glyph '±'
+
   # Disable Powerline fonts
   if [ "$theme_powerline_fonts" = "no" ]
     set __bobthefish_branch_glyph            \u2387
@@ -862,6 +869,11 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
     set __bobthefish_vagrant_poweroff_glyph \uF433 # ↓ 'poweroff'
     set __bobthefish_vagrant_aborted_glyph  \uF468 # ✕ 'aborted'
     set __bobthefish_vagrant_unknown_glyph  \uF421 # strange cases
+  end
+
+  # Avoid ambiguous glyphs
+  if [ "$theme_avoid_ambiguous_glyphs" = "yes" ]
+    set __bobthefish_git_untracked_glyph '...'
   end
 
 


### PR DESCRIPTION
Even if no suitable Powerline/NerdFont alternatives are found, this PR brings the Git implementation closer to the standard of the Vagrant/etc ones, and would be a step towards allowing for external overrides.