### PR TITLE
Feature/cursor on a new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ This theme is based loosely on [agnoster][agnoster].
      * Background jobs (**`%`**)
      * You currently have superpowers (**`$`**)
      * Cursor on newline
-       * Prefix newline with right arrow glyph
-       * Keep right arrow glyph on live above newline
  * Current vi mode
  * `User@Host` (unless you're the default user)
  * Current RVM, rbenv or chruby (Ruby) version
@@ -96,8 +94,6 @@ set -g theme_color_scheme dark
 set -g fish_prompt_pwd_dir_length 0
 set -g theme_project_dir_length 1
 set -g theme_newline_cursor yes
-set -g theme_newline_cursor_arrow_glyph no
-set -g theme_newline_cursor_top_arrow_glyph no
 ```
 
 **Title options**
@@ -116,8 +112,6 @@ set -g theme_newline_cursor_top_arrow_glyph no
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.
 - `theme_newline_cursor`. Use `yes` to have cursor start on a new line. By default the prompt is only one line. When working with long directories it may be preferrend to have cursor on the next line.
-- `theme_newline_cursor_arrow_glyph`. Use `no` have the new line start with a blank space. By default, the default right arrow glyph will be used followed by a single space (' '). Note that this space is required to have a correctly functioning right prompt.
-- `theme_newline_cursor_top_arrow_glyph`. Use `no` to remove the right arrow glyph on the original (top) command prompt line. By default, the right arrow glyph will be used.
 
 **Color scheme options**
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ This theme is based loosely on [agnoster][agnoster].
      * Previous command failed (**`!`**)
      * Background jobs (**`%`**)
      * You currently have superpowers (**`$`**)
+     * Cursor on newline
+       * Prefix newline with right arrow glyph
+       * Keep right arrow glyph on live above newline
  * Current vi mode
  * `User@Host` (unless you're the default user)
  * Current RVM, rbenv or chruby (Ruby) version
@@ -92,6 +95,9 @@ set -g default_user your_normal_user
 set -g theme_color_scheme dark
 set -g fish_prompt_pwd_dir_length 0
 set -g theme_project_dir_length 1
+set -g theme_newline_cursor yes
+set -g theme_newline_cursor_arrow_glyph no
+set -g theme_newline_cursor_top_arrow_glyph no
 ```
 
 **Title options**
@@ -109,6 +115,9 @@ set -g theme_project_dir_length 1
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.
+- `theme_newline_cursor`. Use `yes` to have cursor start on a new line. By default the prompt is only one line. When working with long directories it may be preferrend to have cursor on the next line.
+- `theme_newline_cursor_arrow_glyph`. Use `no` have the new line start with a blank space. By default, the default right arrow glyph will be used followed by a single space (' '). Note that this space is required to have a correctly functioning right prompt.
+- `theme_newline_cursor_top_arrow_glyph`. Use `no` to remove the right arrow glyph on the original (top) command prompt line. By default, the right arrow glyph will be used.
 
 **Color scheme options**
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -408,9 +408,9 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display symbols for a 
       set_color normal
       set_color -b $__color_initial_segment_exit
       if [ "$theme_show_exit_status" = 'yes' ]
-      	echo -ns $last_status ' '
+        echo -ns $last_status ' '
       else
-      	echo -n $__bobthefish_nonzero_exit_glyph
+        echo -n $__bobthefish_nonzero_exit_glyph
       end
     end
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -37,8 +37,6 @@
 #     set -g fish_prompt_pwd_dir_length 0
 #     set -g theme_project_dir_length 1
 #     set -g theme_newline_cursor yes
-#     set -g theme_newline_cursor_arrow_glyph no
-#     set -g theme_newline_cursor_top_arrow_glyph no
 
 # ===========================
 # Helper methods
@@ -279,16 +277,17 @@ function __bobthefish_finish_segments -S -d 'Close open prompt segments'
   if [ "$__bobthefish_current_bg" != '' ]
     set_color normal
     set_color $__bobthefish_current_bg
-    if not [ "$theme_newline_cursor_top_arrow_glyph" = 'no' ]
-      echo -ns $__bobthefish_right_black_arrow_glyph
+    echo -ns $__bobthefish_right_black_arrow_glyph ' '
+  end
+
+  if [ "$theme_newline_cursor" = 'yes' ]
+    echo -ens "\n"
+    set_color $fish_color_autosuggestion
+    if [ "$theme_powerline_fonts" = "no" ]
+      echo -ns '> '
+    else
+      echo -ns "$__bobthefish_right_arrow_glyph "
     end
-    if [ "$theme_newline_cursor" = 'yes' ]
-      echo -ens "\n"
-    end
-    if not [ "$theme_newline_cursor_arrow_glyph" = 'no' ]
-      echo -ns "$__bobthefish_right_black_arrow_glyph"
-    end
-    echo -n ' '
   end
 
   set_color normal

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -36,6 +36,9 @@
 #     set -g theme_color_scheme dark
 #     set -g fish_prompt_pwd_dir_length 0
 #     set -g theme_project_dir_length 1
+#     set -g theme_newline_cursor yes
+#     set -g theme_newline_cursor_arrow_glyph no
+#     set -g theme_newline_cursor_top_arrow_glyph no
 
 # ===========================
 # Helper methods
@@ -276,7 +279,16 @@ function __bobthefish_finish_segments -S -d 'Close open prompt segments'
   if [ "$__bobthefish_current_bg" != '' ]
     set_color normal
     set_color $__bobthefish_current_bg
-    echo -ns $__bobthefish_right_black_arrow_glyph ' '
+    if not [ "$theme_newline_cursor_top_arrow_glyph" = 'no' ]
+      echo -ns $__bobthefish_right_black_arrow_glyph
+    end
+    if [ "$theme_newline_cursor" = 'yes' ]
+      echo -ens "\n"
+    end
+    if not [ "$theme_newline_cursor_arrow_glyph" = 'no' ]
+      echo -ns "$__bobthefish_right_black_arrow_glyph"
+    end
+    echo -n ' '
   end
 
   set_color normal


### PR DESCRIPTION
This will solve #62. I hope it's not too hacky for you. The trick here is the new line needs to start with a character otherwise the right prompt will only show after typing one character. Other than that, I haven't seen any issues.

Here are some pics:

* Default 
```
set -g theme_newline_cursor yes
```
<img width="417" alt="cursor_on_a_newline_righ_arrow_glyph" src="https://user-images.githubusercontent.com/2237523/27007878-ecd3df44-4e2f-11e7-8213-54b8ef6a9a56.png">

* No right arrow glyph on new line
```
set -g theme_newline_cursor yes
set -g theme_newline_cursor_arrow_glyph no
```
<img width="418" alt="cursor_on_a_newline" src="https://user-images.githubusercontent.com/2237523/27007877-ecd1e306-4e2f-11e7-9bfc-3b4da8fdc863.png">

* No right arrow glyph on top line
```
set -g theme_newline_cursor yes
set -g theme_newline_cursor_top_arrow_glyph no
```
<img width="416" alt="cursor_on_a_newline_righ_arrow_glyph_no_top_right_arrow_glyph" src="https://user-images.githubusercontent.com/2237523/27007876-ecd0b436-4e2f-11e7-95fc-2228866ad4c3.png">

* Minimalist
```
set -g theme_newline_cursor yes
set -g theme_newline_cursor_arrow_glyph no
set -g theme_newline_cursor_top_arrow_glyph no
```
<img width="416" alt="cursor_on_a_newline_no_right_arrow_glyphs" src="https://user-images.githubusercontent.com/2237523/27007879-ecd4c38c-4e2f-11e7-9462-220ad785f9e9.png">
