### PR TITLE
Better hybrid mode support for theme_display_vi

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ set -g theme_newline_cursor yes
 
 - `theme_display_ruby`. Use `no` to completely hide all information about Ruby version. By default Ruby version displayed if there is the difference from default settings.
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
-- `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `force` to show the indicator.
+- `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `yes` to show the indicator.
 - `theme_show_exit_status`. Set this option to yes to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ set -g theme_newline_cursor yes
 
 - `theme_display_ruby`. Use `no` to completely hide all information about Ruby version. By default Ruby version displayed if there is the difference from default settings.
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
+- `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `force` to show the indicator.
 - `theme_show_exit_status`. Set this option to yes to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -588,7 +588,7 @@ function __bobthefish_prompt_vi -S -d 'Display vi mode'
   [ "$fish_key_bindings" = 'fish_vi_key_bindings' \
     -o "$fish_key_bindings" = 'hybrid_bindings' \
     -o "$fish_key_bindings" = 'fish_hybrid_key_bindings' \
-    -o "$theme_display_vi" = 'force' ]; or return
+    -o "$theme_display_vi" = 'yes' ]; or return
   switch $fish_bind_mode
     case default
       __bobthefish_start_segment $__color_vi_mode_default

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -586,6 +586,7 @@ end
 function __bobthefish_prompt_vi -S -d 'Display vi mode'
   [ "$theme_display_vi" != 'no' ]; or return
   [ "$fish_key_bindings" = 'fish_vi_key_bindings' \
+    -o "$fish_key_bindings" = 'hybrid_bindings' \
     -o "$fish_key_bindings" = 'fish_hybrid_key_bindings' \
     -o "$theme_display_vi" = 'force' ]; or return
   switch $fish_bind_mode

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -585,7 +585,9 @@ end
 
 function __bobthefish_prompt_vi -S -d 'Display vi mode'
   [ "$theme_display_vi" != 'no' ]; or return
-  [ "$fish_key_bindings" = 'fish_hybrid_key_bindings' -o "$fish_key_bindings" = 'fish_vi_key_bindings' ]; or return
+  [ "$fish_key_bindings" = 'fish_vi_key_bindings' \
+    -o "$fish_key_bindings" = 'fish_hybrid_key_bindings' \
+    -o "$theme_display_vi" = 'force' ]; or return
   switch $fish_bind_mode
     case default
       __bobthefish_start_segment $__color_vi_mode_default


### PR DESCRIPTION
Currently the only way to enable the vi mode indicator is to be using the vanilla `fish_vi_key_bindings` or the (undocumented) `fish_hybrid_key_bindings`.

This PR enables the vi mode indicator by default for people using the `hybrid_bindings` function from the [fish documentation](https://fishshell.com/docs/current/index.html#editor). It also adds an option to either enable and disable the indicator no matter what key bindings function is in use.

This is useful for people who have either copied the function from the fish documentation, or have a custom key bindings function.