### PR TITLE
Add support for ignoring VCS directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ variables to set the colors of the prompt. See the "Colors" section of
 `fish_prompt.fish` for details.
 
 
+**VCS options**
+- `set -g theme_vcs_ignore_paths /some/path/* /some/other/path`. Tells bobthefish to ignore paths for Git or Mercurial. Supports glob patterns.
+
 ### Overrides
 
 You can disable the theme default greeting, vi mode prompt, right prompt, or title entirely — or override with your own — by adding custom functions to `~/.config/fish/functions`:

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -92,8 +92,19 @@ function __bobthefish_pretty_parent -S -a current_dir -d 'Print a parent directo
   string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' "$parent_dir/"
 end
 
+function __ignore_vcs_dir -d 'Identifies if dir is to be ignored for VCS highlighting'
+  for path_ in $theme_vcs_ignore_paths
+    if [ (string match (realpath $path_ ^/dev/null) (realpath $PWD ^/dev/null)) ]
+      echo 1
+      break
+    end
+  end
+end
+
 function __bobthefish_git_project_dir -S -d 'Print the current git project base directory'
   [ "$theme_display_git" = 'no' ]; and return
+  [ (__ignore_vcs_dir) ]; and return
+
   if [ "$theme_git_worktree_support" != 'yes' ]
     command git rev-parse --show-toplevel ^/dev/null
     return
@@ -138,6 +149,8 @@ end
 
 function __bobthefish_hg_project_dir -S -d 'Print the current hg project base directory'
   [ "$theme_display_hg" = 'yes' ]; or return
+  [ (__ignore_vcs_dir) ]; and return
+
   set -l d $PWD
   while not [ $d = / ]
     if [ -e $d/.hg ]


### PR DESCRIPTION
Related to PR #69 but works for both vcs backends (git and hg) and also supports globbed paths.

Signed-off-by: Jesper Derehag <jderehag@hotmail.com>