### PR TITLE
#114 Add asdf ruby version to ruby version prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -586,6 +586,15 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
     [ "$ruby_version" = "$global_ruby_version" ]; and return
   else if type -q chruby
     set ruby_version $RUBY_VERSION
+  else if type -q asdf
+    set -l asdf_ruby_version_str (asdf current ruby ^ /dev/null)
+    if test $status -eq 0
+      set -l asdf_system_origin "(set by $HOME/.tool-versions)"
+      set -l asdf_current_version_provenance (string split -m 1 ' ' $asdf_ruby_version_str)[2]
+      set ruby_version (string split -m 1 ' ' $asdf_ruby_version_str)[1]
+
+      [ "$asdf_current_version_provenance" = "$asdf_system_origin" ]; and return
+    end
   end
   [ -z "$ruby_version" ]; and return
   __bobthefish_start_segment $__color_rvm


### PR DESCRIPTION
Followed established pattern for chruby and rbenv, adding the ruby
version number from asdf to the ruby prompt, only when the local
ruby version differs from the system ruby.

Note that asdf tracks its versions in a dot file (.tool-versions) so
the concept of what is global/system vs what is local simply depends
upon what file asdf is using to determine the correct version.
Fortunately, asdf reports the .tool-versions file when querying for
the current version.

The downside to this is that correct behavior of this patch will
depend upon the format asdf uses for their provenance string.

See https://github.com/asdf-vm/asdf for details about asdf