### PR TITLE
Add verbose option for Git dirty state

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ set -g theme_display_git no
 set -g theme_display_git_dirty no
 set -g theme_display_git_untracked no
 set -g theme_display_git_ahead_verbose yes
+set -g theme_display_git_dirty_verbose yes
 set -g theme_git_worktree_support yes
 set -g theme_display_vagrant yes
 set -g theme_display_docker_machine no

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -21,6 +21,7 @@
 #     set -g theme_display_git_dirty no
 #     set -g theme_display_git_untracked no
 #     set -g theme_display_git_ahead_verbose yes
+#     set -g theme_display_git_dirty_verbose yes
 #     set -g theme_git_worktree_support yes
 #     set -g theme_display_vagrant yes
 #     set -g theme_display_docker_machine no
@@ -239,6 +240,12 @@ function __bobthefish_git_ahead_verbose -S -d 'Print a more verbose ahead/behind
   end
 end
 
+function __bobthefish_git_dirty_verbose -S -d 'Print a more verbose dirty state for the current working tree'
+  set -l changes (command git diff --numstat | awk '{ added += $1; removed += $2 } END { print "+" added "/-" removed }')
+  [ $status != 0 ]; and return
+
+  echo "$changes "
+end
 
 # ==============================
 # Segment functions
@@ -716,7 +723,11 @@ function __bobthefish_prompt_git -S -a current_dir -d 'Display the actual git st
   if [ "$theme_display_git_dirty" != 'no' ]
     set -l show_dirty (command git config --bool bash.showDirtyState ^/dev/null)
     if [ "$show_dirty" != 'false' ]
-      set dirty (command git diff --no-ext-diff --quiet --exit-code ^/dev/null; or echo -n "$__bobthefish_git_dirty_glyph")
+      if [ "$theme_display_git_dirty_verbose" = 'yes' ]
+        set dirty (command git diff --no-ext-diff --quiet --exit-code ^/dev/null; or echo -n "$__bobthefish_git_dirty_glyph"(__bobthefish_git_dirty_verbose))
+      else
+        set dirty (command git diff --no-ext-diff --quiet --exit-code ^/dev/null; or echo -n "$__bobthefish_git_dirty_glyph")
+      end
     end
   end
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -723,10 +723,9 @@ function __bobthefish_prompt_git -S -a current_dir -d 'Display the actual git st
   if [ "$theme_display_git_dirty" != 'no' ]
     set -l show_dirty (command git config --bool bash.showDirtyState ^/dev/null)
     if [ "$show_dirty" != 'false' ]
-      if [ "$theme_display_git_dirty_verbose" = 'yes' ]
-        set dirty (command git diff --no-ext-diff --quiet --exit-code ^/dev/null; or echo -n "$__bobthefish_git_dirty_glyph"(__bobthefish_git_dirty_verbose))
-      else
-        set dirty (command git diff --no-ext-diff --quiet --exit-code ^/dev/null; or echo -n "$__bobthefish_git_dirty_glyph")
+      set dirty (command git diff --no-ext-diff --quiet --exit-code ^/dev/null; or echo -n "$__bobthefish_git_dirty_glyph")
+      if [ "$dirty" -a "$theme_display_git_dirty_verbose" = 'yes' ]
+        set dirty "$dirty"(__bobthefish_git_dirty_verbose)
       end
     end
   end


### PR DESCRIPTION
This adds the one piece of information I found missing from the Git display: an indicator of how many lines have been added/removed when the repo is in a dirty state. Liquidprompt for Bash does this, and I find it very helpful information to see at a glance. I implemented it as a configurable option similarly to `$theme_display_git_ahead_verbose` and defaulted it to off. I also verified that if the verbose options are turned on for both "ahead" and "dirty," it doesn't screw up the display.

Credit to [hughes at Stack Overflow](https://stackoverflow.com/questions/9933325/is-there-a-way-of-having-git-show-lines-added-lines-changed-and-lines-removed#comment55779320_9933440) for the Git and awk commands I used to retrieve the line change stats.