### PR TITLE
Fix issue with filtering out +0/-0

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -244,7 +244,7 @@ function __bobthefish_git_dirty_verbose -S -d 'Print a more verbose dirty state 
   set -l changes (command git diff --numstat | awk '{ added += $1; removed += $2 } END { print "+" added "/-" removed }')
     or return
 
-  echo "$changes " | string replace '+0/' '' | string replace '/-0 ' ' '
+  echo "$changes " | string replace '+0/-0 ' '' | string replace '+0/' '' | string replace '/-0 ' ' '
 end
 
 # ==============================


### PR DESCRIPTION
I discovered that there are some situations where a dirty state can be reported by `git_dirty_verbose` as `+0/-0`. At minimum, I have observed this happening in merge conflicts, and when there is modified, uncommitted content in a submodule. Line 247 would remove the `+0/` but leave behind the `-0` because then it wouldn't match the `/-0` in the second string replacement. I added a check specifically to handle the `+0/-0` special case.