### PR TITLE
Hide user@hostname when using SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ set -g theme_display_virtualenv no
 set -g theme_display_ruby no
 set -g theme_display_user yes
 set -g theme_display_hostname yes
+set -h theme_display_ssh yes
 set -g theme_display_vi no
 set -g theme_display_date no
 set -g theme_display_cmd_duration yes
@@ -118,6 +119,7 @@ set -g theme_newline_cursor yes
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.
 - `theme_newline_cursor`. Use `yes` to have cursor start on a new line. By default the prompt is only one line. When working with long directories it may be preferrend to have cursor on the next line. Setting this to `clean` instead of `yes` suppresses the caret on the new line.
+- `theme_display_ssh`. Use `no` to hide user- and hostname in ssh-sessions.
 
 **Color scheme options**
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ set -g theme_display_k8s_context yes
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
 set -g theme_display_ruby no
-set -g theme_display_user yes
-set -g theme_display_hostname yes
-set -h theme_display_ssh no
+set -g theme_display_user ssh
+set -g theme_display_hostname ssh
 set -g theme_display_vi no
 set -g theme_display_date no
 set -g theme_display_cmd_duration yes
@@ -114,12 +113,13 @@ set -g theme_newline_cursor yes
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
 - `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `yes` to show the indicator.
 - `theme_display_k8s_context`. By default the current kubernetes context is shown (`> kubectl config current-context`). Use `no` to hide the context.
+- `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
+- `theme_display_hostname`. Same behaviour as `theme_display`.
 - `theme_show_exit_status`. Set this option to yes to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.
 - `theme_newline_cursor`. Use `yes` to have cursor start on a new line. By default the prompt is only one line. When working with long directories it may be preferrend to have cursor on the next line. Setting this to `clean` instead of `yes` suppresses the caret on the new line.
-- `theme_display_ssh`. Use `yes` to display user- and hostname in ssh-sessions, even if they're not shown normally.
 
 **Color scheme options**
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ set -g theme_display_virtualenv no
 set -g theme_display_ruby no
 set -g theme_display_user yes
 set -g theme_display_hostname yes
-set -h theme_display_ssh yes
+set -h theme_display_ssh no
 set -g theme_display_vi no
 set -g theme_display_date no
 set -g theme_display_cmd_duration yes
@@ -119,7 +119,7 @@ set -g theme_newline_cursor yes
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.
 - `theme_newline_cursor`. Use `yes` to have cursor start on a new line. By default the prompt is only one line. When working with long directories it may be preferrend to have cursor on the next line. Setting this to `clean` instead of `yes` suppresses the caret on the new line.
-- `theme_display_ssh`. Use `no` to hide user- and hostname in ssh-sessions.
+- `theme_display_ssh`. Use `yes` to display user- and hostname in ssh-sessions, even if they're not shown normally.
 
 **Color scheme options**
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -32,7 +32,7 @@
 #     set -g theme_display_ruby no
 #     set -g theme_display_user yes
 #     set -g theme_display_hostname yes
-#     set -g theme_display_ssh yes
+#     set -g theme_display_ssh no
 #     set -g theme_display_vi no
 #     set -g theme_avoid_ambiguous_glyphs yes
 #     set -g theme_powerline_fonts no

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -32,6 +32,7 @@
 #     set -g theme_display_ruby no
 #     set -g theme_display_user yes
 #     set -g theme_display_hostname yes
+#     set -g theme_display_ssh yes
 #     set -g theme_display_vi no
 #     set -g theme_avoid_ambiguous_glyphs yes
 #     set -g theme_powerline_fonts no
@@ -535,9 +536,9 @@ end
 # ==============================
 
 function __bobthefish_prompt_user -S -d 'Display current user and hostname'
-  [ "$theme_display_user" = 'yes' -o -n "$SSH_CLIENT" -o \( -n "$default_user" -a "$USER" != "$default_user" \) ]
+  [ "$theme_display_user" = 'yes' -o \( "$theme_display_ssh" = 'yes' -a -n "$SSH_CLIENT" \) -o \( -n "$default_user" -a "$USER" != "$default_user" \) ]
     and set -l display_user
-  [ "$theme_display_hostname" = 'yes' -o -n "$SSH_CLIENT" ]
+  [ "$theme_display_hostname" = 'yes' -o \( "$theme_display_ssh" = 'yes' -a -n "$SSH_CLIENT" \) ]
     and set -l display_hostname
 
   if set -q display_user

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -30,9 +30,8 @@
 #     set -g theme_display_hg yes
 #     set -g theme_display_virtualenv no
 #     set -g theme_display_ruby no
-#     set -g theme_display_user yes
-#     set -g theme_display_hostname yes
-#     set -g theme_display_ssh no
+#     set -g theme_display_user ssh
+#     set -g theme_display_hostname ssh
 #     set -g theme_display_vi no
 #     set -g theme_avoid_ambiguous_glyphs yes
 #     set -g theme_powerline_fonts no
@@ -536,9 +535,9 @@ end
 # ==============================
 
 function __bobthefish_prompt_user -S -d 'Display current user and hostname'
-  [ "$theme_display_user" = 'yes' -o \( "$theme_display_ssh" = 'yes' -a -n "$SSH_CLIENT" \) -o \( -n "$default_user" -a "$USER" != "$default_user" \) ]
+  [ "$theme_display_user" = 'yes' -o \( "$theme_display_user" != 'no' -a -n "$SSH_CLIENT" \) -o \( -n "$default_user" -a "$USER" != "$default_user" \) ]
     and set -l display_user
-  [ "$theme_display_hostname" = 'yes' -o \( "$theme_display_ssh" = 'yes' -a -n "$SSH_CLIENT" \) ]
+  [ "$theme_display_hostname" = 'yes' -o \( "$theme_display_hostname" != 'no' -a -n "$SSH_CLIENT" \) ]
     and set -l display_hostname
 
   if set -q display_user


### PR DESCRIPTION
Setting `theme_display_user` and `theme_display_hostname` has no effect when one is logged in via SSH.

I added a switch `theme_display_ssh` that does the following: If
- `"$theme_display_ssh" = 'yes'`: Show user- and hostname when either an ssh-session is detected or `theme_display_user` and `theme_display_hostname` are set to yes.
- `"$theme_display_ssh" = 'no'`: Don't show user- and hostname if showing those isn't enabled.

`theme_display_ssh` defaults to 'no'. This has the advantage of preventing confusion when one has set `theme_display_user` to no explicitly and is logged in via ssh. ;)

Related to #129.