### PR TITLE
Add option to display running command in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ set -g theme_newline_cursor yes
 **Title options**
 
 - `theme_title_display_process`. By default theme doesn't show current process name in terminal title. If you want to show it, just set to `yes`.
-- `theme_title_display_command`. Use `yes` to show current running command in title (this overrides whatever value `theme_title_display_process` has).
+- `theme_title_display_command`. Use `yes` to show current running command in title or show the path if no command is running (this overrides whatever value `theme_title_display_process` and `theme_title_display_path` have).
 - `theme_title_display_path`. Use `no` to hide current working directory from title.
 - `theme_title_display_user`. Set to `yes` to show the current user in the tab title (unless you're the default user).
 - `theme_title_use_abbreviated_path`. Default is `yes`. This means your home directory will be displayed as `~` and `/usr/local` as `/u/local`. Set it to `no` if you prefer full paths in title.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ set -g theme_display_vi no
 set -g theme_display_date no
 set -g theme_display_cmd_duration yes
 set -g theme_title_display_process yes
+set -g theme_title_display_command no
 set -g theme_title_display_path no
 set -g theme_title_display_user yes
 set -g theme_title_use_abbreviated_path no
@@ -104,6 +105,7 @@ set -g theme_newline_cursor yes
 **Title options**
 
 - `theme_title_display_process`. By default theme doesn't show current process name in terminal title. If you want to show it, just set to `yes`.
+- `theme_title_display_command`. Use `yes` to show current running command in title (this overrides whatever value `theme_title_display_process` has).
 - `theme_title_display_path`. Use `no` to hide current working directory from title.
 - `theme_title_display_user`. Set to `yes` to show the current user in the tab title (unless you're the default user).
 - `theme_title_use_abbreviated_path`. Default is `yes`. This means your home directory will be displayed as `~` and `/usr/local` as `/u/local`. Set it to `no` if you prefer full paths in title.

--- a/fish_title.fish
+++ b/fish_title.fish
@@ -1,5 +1,6 @@
 # You can override some default title options in your config.fish:
 #     set -g theme_title_display_process no
+#     set -g theme_title_display_command no
 #     set -g theme_title_display_path no
 #     set -g theme_title_display_user yes
 #     set -g theme_title_use_abbreviated_path no
@@ -14,21 +15,31 @@ function __bobthefish_title_user -S -d 'Display actual user if different from $d
   end
 end
 
+function __display_path -d 'Display the full or abbreviated path'
+  if [ "$theme_title_use_abbreviated_path" = 'no' ]
+    echo $PWD
+  else
+    prompt_pwd
+  end
+end
+
 function fish_title
   __bobthefish_title_user
 
-  if [ "$theme_title_display_process" = 'yes' ]
+  if [ "$theme_title_display_process" = 'yes' -a "$theme_title_display_command" != 'yes' ]
     echo $_
 
     [ "$theme_title_display_path" != 'no' ]
       and echo ' '
-  end
+      and __display_path
+  else
+      if [ "$theme_title_display_path" != 'no' ]
+        __display_path
+        echo ' '
+      end
 
-  if [ "$theme_title_display_path" != 'no' ]
-    if [ "$theme_title_use_abbreviated_path" = 'no' ]
-      echo $PWD
-    else
-      prompt_pwd
-    end
+      if [ $_ != 'fish' ]
+        echo $argv[1]
+      end
   end
 end

--- a/fish_title.fish
+++ b/fish_title.fish
@@ -33,13 +33,9 @@ function fish_title
       and echo ' '
       and __display_path
   else
-      if [ "$theme_title_display_path" != 'no' ]
-        __display_path
-        echo ' '
-      end
-
       if [ $_ != 'fish' ]
         echo $argv[1]
-      end
+      else
+        __display_path
   end
 end


### PR DESCRIPTION
Using `$argv[1]` to get the running command in the title is the example used in the [official docs of fish](http://fishshell.com/docs/current/index.html#title). So I think it's pretty common to want to do that!

Several points to clarify in this PR:

- If `theme_title_display_command` is set to yes, then whatever value `theme_title_display_process` has, it doesn't show it because the command will most certainly have the process name in it.
- If no commands are running, echoing `$argv[1]` would print a `?`. That is why I wrote:
 ```fish
if [ $_ != 'fish' ]
  echo $argv[1]
else
  __display_path
end
```
because the current process would be fish if no commands are running.
In that case, it prints the path whatever the value of `theme_title_display_path` is.

I know it's a pity that this option overrides the two other options but I think it's the best to do because showing a path after showing the running command doesn't really work anyway, the path would appear to be an argument of the command...

Let me know what you think!