### PR TITLE
Change function bobthefish_display_colors to print results using defined environment values

### DIFF
--- a/functions/bobthefish_display_colors.fish
+++ b/functions/bobthefish_display_colors.fish
@@ -38,11 +38,11 @@ function bobthefish_display_colors -a color_scheme -d 'Print example prompt colo
   set_color normal
 
   __bobthefish_start_segment $color_initial_segment_exit
-  echo -n exit '! '
+  echo -n exit $nonzero_exit_glyph
   set_color -b $color_initial_segment_su
-  echo -n su '$ '
+  echo -n su $superuser_glyph
   set_color -b $color_initial_segment_jobs
-  echo -n jobs '% '
+  echo -n jobs $bg_job_glyph
   __bobthefish_finish_segments
   set_color normal
   echo -n "(<- initial_segment)"


### PR DESCRIPTION
It's not much of an issue, but while i was customising the glyphs to my liking, i found that `bobthefish_display_colors`'s behavior does not change when i made a difference in the glyphs at `__bobthefish_glyphs.fish`, so i came up with a solution.

I have no idea why exit, su, and jobs glyphs are the only one printed using a 'fixed value', since every other glyphs in this file is represented in variables.