### PR TITLE
allow custom prompt in new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ set -g theme_color_scheme dark
 set -g fish_prompt_pwd_dir_length 0
 set -g theme_project_dir_length 1
 set -g theme_newline_cursor yes
+set -g theme_newline_prompt '$ '
 ```
 
 **Title options**
@@ -121,6 +122,7 @@ set -g theme_newline_cursor yes
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.
 - `theme_newline_cursor`. Use `yes` to have cursor start on a new line. By default the prompt is only one line. When working with long directories it may be preferrend to have cursor on the next line. Setting this to `clean` instead of `yes` suppresses the caret on the new line.
+- `theme_newline_prompt`. Use a custom prompt with newline cursor. By default this is the chevron right glyph or `>` when powerline fonts are disabled.
 
 **Color scheme options**
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -330,7 +330,7 @@ function __bobthefish_finish_segments -S -d 'Close open prompt segments'
     else
       set prompt "$__bobthefish_right_arrow_glyph "
     end
-    echo -ns "$prompt"
+    echo -ens "$prompt"
   else if [ "$theme_newline_cursor" = 'clean' ]
     echo -ens "\n"
   end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -323,11 +323,14 @@ function __bobthefish_finish_segments -S -d 'Close open prompt segments'
   if [ "$theme_newline_cursor" = 'yes' ]
     echo -ens "\n"
     set_color $fish_color_autosuggestion
-    if [ "$theme_powerline_fonts" = "no" ]
-      echo -ns '> '
+    if [ "$theme_newline_prompt" != '' ]
+      set prompt "$theme_newline_prompt"
+    else if [ "$theme_powerline_fonts" = "no" ]
+      set prompt '> '
     else
-      echo -ns "$right_arrow_glyph "
+      set prompt "$__bobthefish_right_arrow_glyph "
     end
+    echo -ns "$prompt"
   else if [ "$theme_newline_cursor" = 'clean' ]
     echo -ens "\n"
   end


### PR DESCRIPTION
With `set -g theme_newline_prompt '>>> '` you can define your own prompt when `theme_newline_cursor` is set to `yes`

this solves #164 

Also it is possible to use custom utf-8 characters from nerd font as suggested from @forkbomb9