### PR TITLE
Don't show bg_job_glyph after cd command when using autojump

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -361,7 +361,7 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display flags for a no
     and set superuser 1
 
   # Jobs display
-  jobs -p >/dev/null
+  jobs -c | grep -v Command | grep -v autojump >/dev/null
     and set bg_jobs 1
 
   if [ "$nonzero" -o "$superuser" -o "$bg_jobs" ]


### PR DESCRIPTION
`autojump` is executed every time user uses `cd` command. `bobthefish` using `jobs` notices that `autojump` is running and shows `bg_job_glyph` (`%` by default). This commit filters running jobs and shows `bg_job_glyph` only when necessary.