### PR TITLE
Fix: Use a simple prompt on dumb terminals.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -948,6 +948,12 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
     # Save the last status for later (do this before the `set` calls below)
     set -l last_status $status
 
+    # Use a simple prompt on dumb terminals.
+    if test $TERM = "dumb"
+        echo "> "
+        return
+    end
+
     __bobthefish_glyphs
     __bobthefish_colors $theme_color_scheme
 


### PR DESCRIPTION
Dumb terminals don't like this fancy prompt.

This is a really a workaround for loading the theme on demand, but it greatly
simplifies managing plugins and allows just relying on current plugin managers.