### PR TITLE
fix VirtualEnv nerdfonts character in PyCharm

### DIFF
--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -59,7 +59,7 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
     set detached_glyph   \uF417
     set tag_glyph        \uF412
 
-    set virtualenv_glyph \uE73C ' '
+    set virtualenv_glyph \ue606 ' '
     set ruby_glyph       \uE791 ' '
     set go_glyph         \uE626 ' '
 


### PR DESCRIPTION
Previous to this, the character was not displaying. However, it worked in iTerm2. Also, it could be seen in IntelliJ/PyCharm if copy-pasted but not under the blue prompt background.

**Before:**
![image](https://user-images.githubusercontent.com/7644264/46763260-ef826780-cc9e-11e8-890b-37677ca4c2a2.png)


**After:**
![image](https://user-images.githubusercontent.com/7644264/46763204-d7124d00-cc9e-11e8-9e00-502397271b6d.png)
