### PR TITLE
Add Stashes count to Git Prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -285,6 +285,17 @@ function __bobthefish_git_dirty_verbose -S -d 'Print a more verbose dirty state 
     echo "$changes " | string replace -r '(\+0/(-0)?|/-0)' ''
 end
 
+function __bobthefish_git_stashed -S -d 'Print the stashed state for the current branch'
+    set -l stashes (command git rev-list --walk-reflogs --count refs/stash 2>/dev/null)
+    or return
+
+    echo -n "$git_stashed_glyph"
+    if [ "$theme_display_git_stashed_verbose" = 'yes' ]
+        echo -n $stashes
+    end
+
+end
+
 
 # ==============================
 # Segment functions
@@ -828,7 +839,7 @@ function __bobthefish_prompt_git -S -a git_root_dir -d 'Display the actual git s
     end
 
     set -l staged (command git diff --cached --no-ext-diff --quiet --exit-code 2>/dev/null; or echo -n "$git_staged_glyph")
-    set -l stashed (command git rev-parse --verify --quiet refs/stash >/dev/null; and echo -n "$git_stashed_glyph")
+    set -l stashed (__bobthefish_git_stashed)
     set -l ahead (__bobthefish_git_ahead)
 
     set -l new ''

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -286,12 +286,12 @@ function __bobthefish_git_dirty_verbose -S -d 'Print a more verbose dirty state 
 end
 
 function __bobthefish_git_stashed -S -d 'Print the stashed state for the current branch'
-    set -l stashes (command git rev-list --walk-reflogs --count refs/stash 2>/dev/null)
+    command git rev-parse --verify --quiet refs/stash >/dev/null
     or return
 
     echo -n "$git_stashed_glyph"
     if [ "$theme_display_git_stashed_verbose" = 'yes' ]
-        echo -n $stashes
+        echo -n (command git rev-list --walk-reflogs --count refs/stash 2>/dev/null)
     end
 
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -291,7 +291,7 @@ function __bobthefish_git_stashed -S -d 'Print the stashed state for the current
 
     echo -n "$git_stashed_glyph"
     if [ "$theme_display_git_stashed_verbose" = 'yes' ]
-        echo -n (command git rev-list --walk-reflogs --count refs/stash 2>/dev/null)
+        command git rev-list --walk-reflogs --count refs/stash 2>/dev/null
     end
 
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -286,14 +286,14 @@ function __bobthefish_git_dirty_verbose -S -d 'Print a more verbose dirty state 
 end
 
 function __bobthefish_git_stashed -S -d 'Print the stashed state for the current branch'
-    command git rev-parse --verify --quiet refs/stash >/dev/null
-    or return
-
-    echo -n "$git_stashed_glyph"
     if [ "$theme_display_git_stashed_verbose" = 'yes' ]
-        command git rev-list --walk-reflogs --count refs/stash 2>/dev/null
-    end
+        set -l stashed (command git rev-list --walk-reflogs --count refs/stash 2>/dev/null)
+        or return
 
+        echo -n "$git_stashed_glyph$stashed"
+    else
+        command git rev-parse --verify --quiet refs/stash >/dev/null; and echo -n "$git_stashed_glyph"
+    end
 end
 
 


### PR DESCRIPTION
Hi,

This PR aims to implement #187. This is my first attempt in writing scripts in Fish (well, sh scripts in general 😄) so let me know if I have to fix something!

It introduces a new variable, `$theme_display_git_stashed_verbose`, which adds the stashes count to the prompt if set to `yes`