### PR TITLE
fish_greeting.fish: Make existance of uptime command optional

### DIFF
--- a/fish_greeting.fish
+++ b/fish_greeting.fish
@@ -1,6 +1,6 @@
 function fish_greeting -d "What's up, fish?"
     set_color $fish_color_autosuggestion
     uname -nmsr
-    uptime
+    command -q -s uptime; and uptime
     set_color normal
 end


### PR DESCRIPTION
The `uptime` command does not exist in some environments, such as MSYS2,
so execute the command only if it exists.