### PR TITLE
Fix status reporting

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -969,14 +969,14 @@ end
 # ==============================
 
 function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
+    # Save the last status for later (do this before anything else)
+    set -l last_status $status
+
     # Use a simple prompt on dumb terminals.
     if [ "$TERM" = "dumb" ]
         echo "> "
         return
     end
-
-    # Save the last status for later (do this before the `set` calls below)
-    set -l last_status $status
 
     __bobthefish_glyphs
     __bobthefish_colors $theme_color_scheme


### PR DESCRIPTION
The status needs to be saved before anything else is done, otherwise it will get
overwritten.  Since commit ac45a5cb9594 this was the case with the `if` block in
a way that `last_status` was always `0`.