### PR TITLE
Make git branch truncate optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_hostname`. Same behaviour as `theme_display`.
 - `theme_show_exit_status`. Set this option to `yes` to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
+- `theme_truncate_git_branch`. Set this option to `yes` to truncate long git branches.
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.
 - `theme_newline_cursor`. Use `yes` to have cursor start on a new line. By default the prompt is only one line. When working with long directories it may be preferrend to have cursor on the next line. Setting this to `clean` instead of `yes` suppresses the caret on the new line.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -70,6 +70,10 @@ function __bobthefish_git_branch -S -d 'Get the current git branch (or commitish
         and echo $branch_glyph
         and return
 
+        [ "$theme_truncate_git_branch" != 'yes' ]
+        and string replace 'refs/heads/' "$branch_glyph " $ref
+        and return
+
         # truncate the middle of the branch name, but only if it's 25+ characters
         set -l truncname (string replace -r '^(.{28}).{3,}(.{5})$' "\$1…\$2" $ref)
 


### PR DESCRIPTION
The changes on f49a8424cd11f3e2f29807c099d61b7327a0c152 modified the default branch display on prompt.

This pr restores the default behaviour and add a configuration variable to make it optional.

This may solve #195