### PR TITLE
Allow custom named color schemes as plugins.

### DIFF
--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -469,45 +469,49 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_desk                  $comment $bg --bold
 
     case '*' # default dark theme
-      #               light  medium dark
-      #               ------ ------ ------
-      set -l red      cc9999 ce000f 660000
-      set -l green    addc10 189303 0c4801
-      set -l blue     48b4fb 005faf 255e87
-      set -l orange   f6b117 unused 3a2a03
-      set -l brown    bf5e00 803f00 4d2600
-      set -l grey     cccccc 999999 333333
-      set -l white    ffffff
-      set -l black    000000
-      set -l ruby_red af0000
-      set -l go_blue  00d7d7
+      if type -q "__bobthefish_color_scheme_$color_scheme"
+        __bobthefish_color_scheme_$color_scheme
+      else
+        #               light  medium dark
+        #               ------ ------ ------
+        set -l red      cc9999 ce000f 660000
+        set -l green    addc10 189303 0c4801
+        set -l blue     48b4fb 005faf 255e87
+        set -l orange   f6b117 unused 3a2a03
+        set -l brown    bf5e00 803f00 4d2600
+        set -l grey     cccccc 999999 333333
+        set -l white    ffffff
+        set -l black    000000
+        set -l ruby_red af0000
+        set -l go_blue  00d7d7
 
-      set -x color_initial_segment_exit     $white $red[2] --bold
-      set -x color_initial_segment_su       $white $green[2] --bold
-      set -x color_initial_segment_jobs     $white $blue[3] --bold
+        set -x color_initial_segment_exit     $white $red[2] --bold
+        set -x color_initial_segment_su       $white $green[2] --bold
+        set -x color_initial_segment_jobs     $white $blue[3] --bold
 
-      set -x color_path                     $grey[3] $grey[2]
-      set -x color_path_basename            $grey[3] $white --bold
-      set -x color_path_nowrite             $red[3] $red[1]
-      set -x color_path_nowrite_basename    $red[3] $red[1] --bold
+        set -x color_path                     $grey[3] $grey[2]
+        set -x color_path_basename            $grey[3] $white --bold
+        set -x color_path_nowrite             $red[3] $red[1]
+        set -x color_path_nowrite_basename    $red[3] $red[1] --bold
 
-      set -x color_repo                     $green[1] $green[3]
-      set -x color_repo_work_tree           $grey[3] $white --bold
-      set -x color_repo_dirty               $red[2] $white
-      set -x color_repo_staged              $orange[1] $orange[3]
+        set -x color_repo                     $green[1] $green[3]
+        set -x color_repo_work_tree           $grey[3] $white --bold
+        set -x color_repo_dirty               $red[2] $white
+        set -x color_repo_staged              $orange[1] $orange[3]
 
-      set -x color_vi_mode_default          $grey[2] $grey[3] --bold
-      set -x color_vi_mode_insert           $green[2] $grey[3] --bold
-      set -x color_vi_mode_visual           $orange[1] $orange[3] --bold
+        set -x color_vi_mode_default          $grey[2] $grey[3] --bold
+        set -x color_vi_mode_insert           $green[2] $grey[3] --bold
+        set -x color_vi_mode_visual           $orange[1] $orange[3] --bold
 
-      set -x color_vagrant                  $blue[1] $white --bold
-      set -x color_k8s                      $green[2] $white --bold
-      set -x color_username                 $grey[1] $blue[3] --bold
-      set -x color_hostname                 $grey[1] $blue[3]
-      set -x color_rvm                      $ruby_red $grey[1] --bold
-      set -x color_virtualfish              $blue[2] $grey[1] --bold
-      set -x color_virtualgo                $go_blue $black --bold
-      set -x color_desk                     $blue[2] $grey[1] --bold
+        set -x color_vagrant                  $blue[1] $white --bold
+        set -x color_k8s                      $green[2] $white --bold
+        set -x color_username                 $grey[1] $blue[3] --bold
+        set -x color_hostname                 $grey[1] $blue[3]
+        set -x color_rvm                      $ruby_red $grey[1] --bold
+        set -x color_virtualfish              $blue[2] $grey[1] --bold
+        set -x color_virtualgo                $go_blue $black --bold
+        set -x color_desk                     $blue[2] $grey[1] --bold
+      end
   end
 end
 


### PR DESCRIPTION
This will allow users to keep repositories of named color schemes, and to share them with everyone.

Example: [theme-bobthefish-colorschemes](https://github.com/dukejones/theme-bobthefish-colorschemes)

Working version of the Monokai example from the wiki pasted below:
```fish

function __bobthefish_color_scheme_monokai -S -d 'Monokai colors'
  __bobthefish_colors base16-dark

  set -l base00 272822
  set -l base01 383830
  set -l base02 49483e
  set -l base03 75715e
  set -l base04 a59f85
  set -l base05 f8f8f2
  set -l base06 f5f4f1
  set -l base07 f9f8f5
  set -l base08 f92672 # red
  set -l base09 fd971f # orange
  set -l base0A f4bf75 # yellow
  set -l base0B a6e22e # green
  set -l base0C a1efe4 # cyan
  set -l base0D 66d9ef # blue
  set -l base0E ae81ff # violet
  set -l base0F cc6633 # brown

  set -l colorfg $base02

  set -x color_initial_segment_exit     $base05 $base08 --bold
  set -x color_initial_segment_su       $base05 $base0B --bold
  set -x color_initial_segment_jobs     $base05 $base0D --bold

  set -x color_path                     $base02 $base05
  set -x color_path_basename            $base02 $base06 --bold
  set -x color_path_nowrite             $base02 $base08
  set -x color_path_nowrite_basename    $base02 $base08 --bold

  set -x color_repo                     $base0B $colorfg
  set -x color_repo_work_tree           $base02 $colorfg --bold
  set -x color_repo_dirty               $base08 $colorfg
  set -x color_repo_staged              $base09 $colorfg

  set -x color_vi_mode_default          $base03 $colorfg --bold
  set -x color_vi_mode_insert           $base0B $colorfg --bold
  set -x color_vi_mode_visual           $base09 $colorfg --bold

  set -x color_vagrant                  $base0C $colorfg --bold
  set -x color_username                 $base02 $base0D --bold
  set -x color_hostname                 $base02 $base0D
  set -x color_rvm                      $base08 $colorfg --bold
  set -x color_virtualfish              $base0D $colorfg --bold
  set -x color_virtualgo                $base0D $colorfg --bold
  set -x color_desk                     $base0D $colorfg --bold
end

```