### PR TITLE
Add NVM prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This theme is based loosely on [agnoster][agnoster].
  * Current RVM, rbenv or chruby (Ruby) version
  * Current virtualenv (Python) version
      * _If you use virtualenv, you will probably need to disable the default virtualenv prompt, since it doesn't play nice with fish: `set -x VIRTUAL_ENV_DISABLE_PROMPT 1`_
+ * Current NVM version (Nodejs) (inactive by default; see configurations in the next paragraph)
  * Abbreviated parent directory
  * Current directory, or Git or Mercurial project name
  * Current project's repo branch (<img width="16" alt="branch-glyph" src="https://cloud.githubusercontent.com/assets/53660/8768360/53ee9b58-2e32-11e5-9977-cee0063936fa.png"> master) or detached head (`➦` d0dfd9b)
@@ -81,6 +82,7 @@ set -g theme_display_k8s_context yes
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
 set -g theme_display_ruby no
+set -g theme_display_nvm yes
 set -g theme_display_user ssh
 set -g theme_display_hostname ssh
 set -g theme_display_vi no
@@ -113,6 +115,7 @@ set -g theme_newline_prompt '$ '
 **Prompt options**
 
 - `theme_display_ruby`. Use `no` to completely hide all information about Ruby version. By default Ruby version displayed if there is the difference from default settings.
+- `theme_display_nvm`. If set to `yes`, will display current NVM node version.
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
 - `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `yes` to show the indicator.
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -34,6 +34,7 @@
 #     set -g theme_display_user ssh
 #     set -g theme_display_hostname ssh
 #     set -g theme_display_vi no
+#     set -g theme_display_nvm yes
 #     set -g theme_avoid_ambiguous_glyphs yes
 #     set -g theme_powerline_fonts no
 #     set -g theme_nerd_fonts yes
@@ -801,6 +802,20 @@ function __bobthefish_prompt_desk -S -d 'Display current desk environment'
     set_color normal
 end
 
+function __bobthefish_prompt_nvm -S -d 'Display current node version through NVM'
+    [ "$theme_display_nvm" = 'yes' -a -n "$NVM_DIR" ]
+    or return
+
+    set -l node_version (nvm current 2> /dev/null)
+
+    [ -z $node_version -o "$node_version" = 'none' ]
+    and return
+
+    __bobthefish_start_segment $color_nvm
+    echo -ns $node_glyph $node_version ' '
+    set_color normal
+end
+
 
 # ==============================
 # VCS segments
@@ -1004,6 +1019,7 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
     __bobthefish_prompt_rubies
     __bobthefish_prompt_virtualfish
     __bobthefish_prompt_virtualgo
+    __bobthefish_prompt_nvm
 
     set -l real_pwd (__bobthefish_pwd)
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -808,7 +808,7 @@ function __bobthefish_prompt_nvm -S -d 'Display current node version through NVM
 
     set -l node_version (nvm current 2> /dev/null)
 
-    [ -z $node_version -o "$node_version" = 'none' ]
+    [ -z $node_version -o "$node_version" = 'none' -o "$node_version" = 'system' ]
     and return
 
     __bobthefish_start_segment $color_nvm

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -30,6 +30,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 white black --bold
       set -x color_hostname                 white black
       set -x color_rvm                      brmagenta $colorfg --bold
+      set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
@@ -60,6 +61,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 black white --bold
       set -x color_hostname                 black white
       set -x color_rvm                      brmagenta $colorfg --bold
+      set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
@@ -90,6 +92,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 brgrey white --bold
       set -x color_hostname                 brgrey white
       set -x color_rvm                      brmagenta $colorfg --bold
+      set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
@@ -120,6 +123,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 grey black --bold
       set -x color_hostname                 grey black
       set -x color_rvm                      brmagenta $colorfg --bold
+      set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
@@ -156,6 +160,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 $grey $blue --bold
       set -x color_hostname                 $grey $blue
       set -x color_rvm                      $red $grey --bold
+      set -x color_nvm                      $green $white --bold
       set -x color_virtualfish              $blue $grey --bold
       set -x color_virtualgo                $blue $grey --bold
       set -x color_desk                     $blue $grey --bold
@@ -203,6 +208,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
+      set -x color_nvm                      $base0B $colorfg --bold
       set -x color_virtualfish              $base0D $colorfg --bold
       set -x color_virtualgo                $base0D $colorfg --bold
       set -x color_desk                     $base0D $colorfg --bold
@@ -250,6 +256,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
+      set -x color_nvm                      $base0B $colorfg --bold
       set -x color_virtualfish              $base0D $colorfg --bold
       set -x color_virtualgo                $base0D $colorfg --bold
       set -x color_desk                     $base0D $colorfg --bold
@@ -297,6 +304,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 $base2 $blue --bold
       set -x color_hostname                 $base2 $blue
       set -x color_rvm                      $red $colorfg --bold
+      set -x color_nvm                      $green $colorfg --bold
       set -x color_virtualfish              $cyan $colorfg --bold
       set -x color_virtualgo                $cyan $colorfg --bold
       set -x color_desk                     $cyan $colorfg --bold
@@ -344,6 +352,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 $base02 $blue --bold
       set -x color_hostname                 $base02 $blue
       set -x color_rvm                      $red $colorfg --bold
+      set -x color_nvm                      $green $colorfg --bold
       set -x color_virtualfish              $cyan $colorfg --bold
       set -x color_virtualgo                $cyan $colorfg --bold
       set -x color_desk                     $cyan $colorfg --bold
@@ -384,6 +393,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold
+      set -x color_nvm                      $green $grey[1] --bold
       set -x color_virtualfish              $blue[2] $grey[1] --bold
       set -x color_virtualgo                $blue[2] $grey[1] --bold
       set -x color_desk                     $blue[2] $grey[1] --bold
@@ -423,6 +433,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username              $fg[3] $blue[2] --bold
       set -x color_hostname              $fg[3] $blue[2]
       set -x color_rvm                   $red[2] $fg[2] --bold
+      set -x color_nvm                   $green[1] $fg[2] --bold
       set -x color_virtualfish           $blue[2] $fg[2] --bold
       set -x color_virtualgo             $blue[2] $fg[2] --bold
       set -x color_desk                  $blue[2] $fg[2] --bold
@@ -464,6 +475,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username              $selection $cyan --bold
       set -x color_hostname              $selection $cyan
       set -x color_rvm                   $red $bg --bold
+      set -x color_nvm                   $green $bg --bold
       set -x color_virtualfish           $comment $bg --bold
       set -x color_virtualgo             $cyan $bg --bold
       set -x color_desk                  $comment $bg --bold
@@ -505,6 +517,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold
+      set -x color_nvm                      $green[1] $white --bold
       set -x color_virtualfish              $blue[2] $grey[1] --bold
       set -x color_virtualgo                $go_blue $black --bold
       set -x color_desk                     $blue[2] $grey[1] --bold

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -62,6 +62,7 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
     set virtualenv_glyph \uE73C ' '
     set ruby_glyph       \uE791 ' '
     set go_glyph         \uE626 ' '
+    set node_glyph       \uF898 ' '
 
     set vagrant_running_glyph  \uF431 # ↑ 'running'
     set vagrant_poweroff_glyph \uF433 # ↓ 'poweroff'

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -62,7 +62,7 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
     set virtualenv_glyph \uE73C ' '
     set ruby_glyph       \uE791 ' '
     set go_glyph         \uE626 ' '
-    set node_glyph       \uF898 ' '
+    set node_glyph       \uE718 ' '
 
     set vagrant_running_glyph  \uF431 # ↑ 'running'
     set vagrant_poweroff_glyph \uF433 # ↓ 'poweroff'


### PR DESCRIPTION
As it says. Should fix #97 

Sincerly I'm not 100% sure about colors I've used for all the themes: I chose the green and applied it down to all the supported color schemes.

Since this is a PR on a project I do not maintain, I decided to have this prompt disabled by default.

If NVM version is deactivated (`nvm deactivate`) the nvm prompt won't show. I'm open to other/smarter methods to understand if we're not on an nvm's node version.

Documentation should be ok also.

Note: this is a specific PR done for NVM, hence it's not meant to supersede the (stalled?) #128 