### PR TITLE
Added the k8s namespace value to the prompt and the k8s icon to the segment

### DIFF
--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -25,6 +25,9 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
   # Desk glyphs
   set -x desk_glyph              \u25F2
 
+  # Kubernetes glyphs
+  set -x k8s_glyph               \u2388 # '⎈'
+
   # Vagrant glyphs
   set -x vagrant_running_glyph   \u2191 # ↑ 'running'
   set -x vagrant_poweroff_glyph  \u2193 # ↓ 'poweroff'


### PR DESCRIPTION
1. The current Kubernetes namespace is displayed if the current context is not empty and defaults to "default".
2. The `⎈` glyph has been added to the k8s prompt segment.

Fixes #198. 