### PR TITLE
Add option to display the number of background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ set -g theme_avoid_ambiguous_glyphs yes
 set -g theme_powerline_fonts no
 set -g theme_nerd_fonts yes
 set -g theme_show_exit_status yes
-set -g theme_show_job_number yes
+set -g theme_display_jobs_verbose yes
 set -g default_user your_normal_user
 set -g theme_color_scheme dark
 set -g fish_prompt_pwd_dir_length 0
@@ -124,7 +124,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_show_exit_status`. Set this option to `yes` to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
-- `theme_show_job_number`. If set to `yes` this option displays the number of currently running background jobs next to the percent sign.
+- `theme_display_jobs_verbose`. If set to `yes` this option displays the number of currently running background jobs next to the percent sign.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
 - `theme_use_abbreviated_branch_name`. Set to `yes` to truncate git branch names in the prompt.
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ set -g theme_avoid_ambiguous_glyphs yes
 set -g theme_powerline_fonts no
 set -g theme_nerd_fonts yes
 set -g theme_show_exit_status yes
+set -g theme_show_job_number yes
 set -g default_user your_normal_user
 set -g theme_color_scheme dark
 set -g fish_prompt_pwd_dir_length 0
@@ -123,6 +124,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_show_exit_status`. Set this option to `yes` to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
+- `theme_show_job_number`. If set to `yes` this option displays the number of currently running background jobs next to the percent sign.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
 - `theme_use_abbreviated_branch_name`. Set to `yes` to truncate git branch names in the prompt.
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -39,7 +39,7 @@
 #     set -g theme_powerline_fonts no
 #     set -g theme_nerd_fonts yes
 #     set -g theme_show_exit_status yes
-#     set -g theme_show_job_number yes
+#     set -g theme_display_jobs_verbose yes
 #     set -g default_user your_normal_user
 #     set -g theme_color_scheme dark
 #     set -g fish_prompt_pwd_dir_length 0
@@ -451,7 +451,7 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display flags for a no
         if [ "$bg_jobs" ]
             set_color normal
             set_color -b $color_initial_segment_jobs
-            if [ "$theme_show_job_number" = 'yes' ]
+            if [ "$theme_display_jobs_verbose" = 'yes' ]
                 echo -ns $bg_job_glyph $bg_jobs ' '
             else
                 echo -n $bg_job_glyph

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -39,6 +39,7 @@
 #     set -g theme_powerline_fonts no
 #     set -g theme_nerd_fonts yes
 #     set -g theme_show_exit_status yes
+#     set -g theme_show_job_number yes
 #     set -g default_user your_normal_user
 #     set -g theme_color_scheme dark
 #     set -g fish_prompt_pwd_dir_length 0
@@ -420,7 +421,8 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display flags for a no
     and set superuser 1
 
     # Jobs display
-    jobs -p >/dev/null
+    set num_bg_jobs (jobs -p | wc -l)
+    [ $num_bg_jobs -gt 0 ]
     and set bg_jobs 1
 
     if [ "$nonzero" -o "$superuser" -o "$bg_jobs" ]
@@ -449,7 +451,11 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display flags for a no
         if [ "$bg_jobs" ]
             set_color normal
             set_color -b $color_initial_segment_jobs
-            echo -n $bg_job_glyph
+            if [ "$theme_show_job_number" = 'yes' ]
+                echo -ns $bg_job_glyph $bg_jobs ' '
+            else
+                echo -n $bg_job_glyph
+            end
         end
     end
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -421,9 +421,14 @@ function __bobthefish_prompt_status -S -a last_status -d 'Display flags for a no
     and set superuser 1
 
     # Jobs display
-    set num_bg_jobs (jobs -p | wc -l)
-    [ $num_bg_jobs -gt 0 ]
-    and set bg_jobs 1
+    if [ "$theme_display_jobs_verbose" = 'yes' ]
+        set bg_jobs (jobs -p | wc -l)
+        [ "$bg_jobs" -eq 0 ]
+        and set bg_jobs # clear it out so it doesn't show when `0`
+    else
+        jobs -p >/dev/null
+        and set bg_jobs 1
+    end
 
     if [ "$nonzero" -o "$superuser" -o "$bg_jobs" ]
         __bobthefish_start_segment $color_initial_segment_exit


### PR DESCRIPTION
This adds another option (`theme_show_job_number`) that can be set to `yes` in the `config.fish` to display the number of background jobs next to the percent sign.