### PR TITLE
Simplify kubernetes context fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
 - `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `yes` to show the indicator.
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).
+- `theme_display_k8s_namespace`. This feature is disabled by default. Use `yes` to show the current kubernetes namespace.
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_show_exit_status`. Set this option to `yes` to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -28,6 +28,7 @@
 #     set -g theme_display_vagrant yes
 #     set -g theme_display_docker_machine no
 #     set -g theme_display_k8s_context yes
+#     set -g theme_display_k8s_namespace no
 #     set -g theme_display_hg yes
 #     set -g theme_display_virtualenv no
 #     set -g theme_display_ruby no
@@ -627,7 +628,8 @@ function __bobthefish_prompt_k8s_context -S -d 'Show current Kubernetes context'
     set -l context (__bobthefish_k8s_context)
     or return
 
-    set -l namespace (__bobthefish_k8s_namespace)
+    [ "$theme_display_k8s_namespace" = 'yes' ]
+    and set -l namespace (__bobthefish_k8s_namespace)
 
     set -l segment $k8s_glyph " " $context
     [ -n "$namespace" ]


### PR DESCRIPTION
I've started notice a small delay when rendering the prompt and tracked
the issue down to the kubernetes part.

Turns out it actually does take a few 100ms to both open the file, and
then run `kubectl config view` (which also opens the file). This PR gets
both the context and the namespace from the `kubectl config view`
command.

This change does have the drawback that if there is no namespace at,
the colon `:` would still be displayed. I'm not familiar enough with
jsonpath to work this out at this time.