### PR TITLE
Use `command uptime` to avoid coloured output when using grc plugin

### DIFF
--- a/fish_greeting.fish
+++ b/fish_greeting.fish
@@ -4,7 +4,7 @@ function fish_greeting -d "What's up, fish?"
 
     # TODO: `command -q -s` only works on fish 2.5+, so hold off on that for now
     command -s uptime >/dev/null
-    and uptime
+    and command uptime
 
     set_color normal
 end


### PR DESCRIPTION
When using the generic colouriser plugin the output of `uptime` would be coloured. Since I think it is not the intention to have a coloured greeting, using `command uptime` prevents the overriding of the colourisation by `grc`.