### PR TITLE
Add option to display sudo-username.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
+- `theme_display_sudo_user`. If set to `yes`, displays the sudo-username in a root shell. For example, when calling `sudo -s` and having this option set to `yes`, the username of the user, who called `sudo -s`, will be displayed.
 - `theme_show_exit_status`. Set this option to `yes` to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 - `theme_display_jobs_verbose`. If set to `yes` this option displays the number of currently running background jobs next to the percent sign.
 - `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -692,6 +692,7 @@ function __bobthefish_prompt_user -S -d 'Display current user and hostname'
     end
 
     set -q display_user
+    or set -q display_sudo_user
     or set -q display_hostname
     and echo -ns ' '
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -33,6 +33,7 @@
 #     set -g theme_display_ruby no
 #     set -g theme_display_user ssh
 #     set -g theme_display_hostname ssh
+#     set -g theme_display_sudo_user yes
 #     set -g theme_display_vi no
 #     set -g theme_display_nvm yes
 #     set -g theme_avoid_ambiguous_glyphs yes
@@ -654,8 +655,11 @@ if not type -q prompt_hostname
 end
 
 function __bobthefish_prompt_user -S -d 'Display current user and hostname'
-    [ "$theme_display_user" = 'yes' -o \( "$theme_display_user" != 'no' -a -n "$SSH_CLIENT" \) -o \( -n "$default_user" -a "$USER" != "$default_user" \) -o -n "$SUDO_USER" ]
+    [ "$theme_display_user" = 'yes' -o \( "$theme_display_user" != 'no' -a -n "$SSH_CLIENT" \) -o \( -n "$default_user" -a "$USER" != "$default_user" \) ]
     and set -l display_user
+
+    [ "$theme_display_sudo_user" = 'yes' -a -n "$SUDO_USER" ]
+    and set -l display_sudo_user
 
     [ "$theme_display_hostname" = 'yes' -o \( "$theme_display_hostname" != 'no' -a -n "$SSH_CLIENT" \) ]
     and set -l display_hostname
@@ -663,6 +667,15 @@ function __bobthefish_prompt_user -S -d 'Display current user and hostname'
     if set -q display_user
         __bobthefish_start_segment $color_username
         echo -ns (whoami)
+    end
+
+    if set -q display_sudo_user
+        if set -q display_user
+            echo -ns ' '
+        else
+            __bobthefish_start_segment $color_username
+        end
+        echo -ns "($SUDO_USER)"
     end
 
     if set -q display_hostname

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -679,7 +679,7 @@ function __bobthefish_prompt_user -S -d 'Display current user and hostname'
     end
 
     if set -q display_hostname
-        if set -q display_user
+        if set -q display_user; or set -q display_sudo_user
             # reset colors without starting a new segment...
             # (so we can have a bold username and non-bold hostname)
             set_color normal


### PR DESCRIPTION
This adds another config option `theme_display_sudo_user`. When set to `yes` it displays the content of `$SUDO_USER` in the username segment of the prompt. 

This means that if a user called `normal_user` calls `sudo -s`, for example, and has this option and `theme_display_user` set to yes, the prompt would display `root (normal_user)` in the username segment.  
If `theme_display_user` is not set to `yes` but `theme_display_sudo_user` is, the prompt would display just `(normal_user)` in the username segment.  