### PR TITLE
README: Clarify git_worktree_support default

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_show_exit_status`. Set this option to `yes` to have the prompt show the last exit code if it was non_zero instead of just the exclamation mark.
 - `theme_display_jobs_verbose`. If set to `yes` this option displays the number of currently running background jobs next to the percent sign.
-- `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, leave it disabled. It's faster this way :)
+- `theme_git_worktree_support`. If you do any git worktree shenanigans, setting this to `yes` will fix incorrect project-relative path display. If you don't do any git worktree shenanigans, disable it. It's faster this way :)
 - `theme_use_abbreviated_branch_name`. Set to `yes` to truncate git branch names in the prompt.
 - `fish_prompt_pwd_dir_length`. bobthefish respects the Fish `$fish_prompt_pwd_dir_length` setting to abbreviate the prompt path. Set to `0` to show the full path, `1` (default) to show only the first character of each parent directory name, or any other number to show up to that many characters.
 - `theme_project_dir_length`. The same as `$fish_prompt_pwd_dir_length`, but for the path relative to the current project root. Defaults to `0`; set to any other number to show an abbreviated path.


### PR DESCRIPTION
`theme_git_worktree_support` is enabled by default. The wording "leave it disabled" suggests the option would be disabled.

![image](https://user-images.githubusercontent.com/13085980/67621842-0517f000-f814-11e9-84c1-849ae4526ed6.png)
https://github.com/oh-my-fish/theme-bobthefish/blob/master/README.md#configuration