### PR TITLE
improve $HOME detection for superuser on macOS (fixes #219)

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -359,7 +359,7 @@ function __bobthefish_path_segment -S -a segment_dir -d 'Display a shortened for
     switch "$segment_dir"
         case /
             set directory '/'
-        case "$HOME"
+        case (builtin realpath "$HOME")
             set directory '~'
         case '*'
             set parent (__bobthefish_pretty_parent "$segment_dir")


### PR DESCRIPTION
On macOS, root's $HOME is '/var/root' but '/var' is a symlink to '/var/private'. Consequently, $HOME ('/var/'root') never matches a normalized $PWD ('/var/private/root') and '~' is never displayed.