### PR TITLE
improve path resolution of git/hg root directory (fixes #219)

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -113,8 +113,7 @@ function __bobthefish_pretty_parent -S -a child_dir -d 'Print a parent directory
 end
 
 function __bobthefish_ignore_vcs_dir -d 'Check whether the current directory should be ignored as a VCS segment'
-    for p in $theme_vcs_ignore_paths
-        set ignore_path (realpath $p 2>/dev/null)
+    for ignore_path in $theme_vcs_ignore_paths
         switch $PWD/
             case $ignore_path/\*
                 echo 1


### PR DESCRIPTION
The fixes for #181 and #191 introduce the use of `pwd -P` to normalize
$PWD but this prevents the display of $HOME as ~ in cases where $HOME
contains a symlink.

Rather than passing normalized $PWD everywhere, this commit
proposes to improve path reoslution for git/hg root directory in the
respective functions. This commit addresses #181 but has not been
tested for #191.