### PR TITLE
Use repo root when looking for untracked files

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -932,7 +932,7 @@ function __bobthefish_prompt_git -S -a git_root_dir -a real_pwd -d 'Display the 
     if [ "$theme_display_git_untracked" != 'no' ]
         set -l show_untracked (command git config --bool bash.showUntrackedFiles 2>/dev/null)
         if [ "$show_untracked" != 'false' ]
-            set new (command git ls-files --other --exclude-standard --directory --no-empty-directory 2>/dev/null)
+            set new (command git ls-files --other --exclude-standard --directory --no-empty-directory (git rev-parse --show-toplevel) 2>/dev/null)
             if [ "$new" ]
                 set new "$git_untracked_glyph"
             end


### PR DESCRIPTION
Currently, if you add a new file to a subdirectory in a git repo then cd to a sibling directory, the untracked glyph will not appear. This is inconsistent with the behavior of the other git colors and flags, e.g. if you modify a file and cd into a sibling directory, the prompt will still be red and the dirty working directory glyph will still appear.

Here's an example of the current behavior:
![untracked-glyph-missing](https://user-images.githubusercontent.com/9344511/68810230-a89e3880-063b-11ea-805d-5f39fba8b9f8.png)

This PR modifies the query used to find untracked files so it searches from the repo root instead of the current directory.

Here's the same directory with these changes applied:
![untracked-glyph-fixed](https://user-images.githubusercontent.com/9344511/68810311-dedbb800-063b-11ea-9954-1d42118f0da8.png)