### PR TITLE
Add OS type detection and custom coloring for root user

### DIFF
--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -28,13 +28,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_username                 white black --bold
+      set -x color_root_username            red white --bold
       set -x color_hostname                 white black
       set -x color_rvm                      brmagenta $colorfg --bold
       set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
-
+      set -x color_currentos                green $colorfg --bold
     case 'terminal-light*'
       set -l colorfg white
       [ "$color_scheme" = 'terminal-light-black' ]; and set colorfg black
@@ -59,12 +60,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_username                 black white --bold
+      set -x color_root_username            red white --bold
       set -x color_hostname                 black white
       set -x color_rvm                      brmagenta $colorfg --bold
       set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
+      set -x color_currentos                green $colorfg --bold
 
     case 'terminal2' 'terminal2-dark*'
       set -l colorfg black
@@ -90,12 +93,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_username                 brgrey white --bold
+      set -x color_root_username            red white --bold
       set -x color_hostname                 brgrey white
       set -x color_rvm                      brmagenta $colorfg --bold
       set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
+      set -x color_currentos                green $colorfg --bold
 
     case 'terminal2-light*'
       set -l colorfg white
@@ -121,12 +126,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_username                 grey black --bold
+      set -x color_root_username            red black --bold
       set -x color_hostname                 grey black
       set -x color_rvm                      brmagenta $colorfg --bold
       set -x color_nvm                      brgreen $colorfg --bold
       set -x color_virtualfish              brblue $colorfg --bold
       set -x color_virtualgo                brblue $colorfg --bold
       set -x color_desk                     brblue $colorfg --bold
+      set -x color_currentos                green $colorfg --bold
 
     case 'zenburn'
       set -l grey   333333 # a bit darker than normal zenburn grey
@@ -158,12 +165,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $blue $green --bold
       set -x color_k8s                      $green $white --bold
       set -x color_username                 $grey $blue --bold
+      set -x color_root_username            $gray $red --bold
       set -x color_hostname                 $grey $blue
       set -x color_rvm                      $red $grey --bold
       set -x color_nvm                      $green $white --bold
       set -x color_virtualfish              $blue $grey --bold
       set -x color_virtualgo                $blue $grey --bold
       set -x color_desk                     $blue $grey --bold
+      set -x color_currentos                $green $white --bold
 
     case 'base16-light'
       set -l base00 181818
@@ -206,12 +215,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base06 $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
+      set -x color_root_username            $base08 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
       set -x color_nvm                      $base0B $colorfg --bold
       set -x color_virtualfish              $base0D $colorfg --bold
       set -x color_virtualgo                $base0D $colorfg --bold
       set -x color_desk                     $base0D $colorfg --bold
+      set -x color_currentos                $base0B $colorfg --bold
 
     case 'base16' 'base16-dark'
       set -l base00 181818
@@ -254,12 +265,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base0B $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
+      set -x color_root_username            $base08 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
       set -x color_nvm                      $base0B $colorfg --bold
       set -x color_virtualfish              $base0D $colorfg --bold
       set -x color_virtualgo                $base0D $colorfg --bold
       set -x color_desk                     $base0D $colorfg --bold
+      set -x color_currentos                $base0B $colorfg --bold
 
     case 'solarized-light'
       set -l base03  002b36
@@ -302,12 +315,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
       set -x color_username                 $base2 $blue --bold
+      set -x color_root_username            $base2 $red --bold
       set -x color_hostname                 $base2 $blue
       set -x color_rvm                      $red $colorfg --bold
       set -x color_nvm                      $green $colorfg --bold
       set -x color_virtualfish              $cyan $colorfg --bold
       set -x color_virtualgo                $cyan $colorfg --bold
       set -x color_desk                     $cyan $colorfg --bold
+      set -x color_currentos                $green $colorfg --bold
 
     case 'solarized' 'solarized-dark'
       set -l base03  002b36
@@ -350,12 +365,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
       set -x color_username                 $base02 $blue --bold
+      set -x color_root_username            $base2 $red --bold
       set -x color_hostname                 $base02 $blue
       set -x color_rvm                      $red $colorfg --bold
       set -x color_nvm                      $green $colorfg --bold
       set -x color_virtualfish              $cyan $colorfg --bold
       set -x color_virtualgo                $cyan $colorfg --bold
       set -x color_desk                     $cyan $colorfg --bold
+      set -x color_currentos                $green $colorfg --bold
 
     case 'light'
       #               light  medium dark
@@ -391,12 +408,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[1] $colorfg --bold
       set -x color_username                 $grey[1] $blue[3] --bold
+      set -x color_root_username            $grey[1] $red --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold
       set -x color_nvm                      $green $grey[1] --bold
       set -x color_virtualfish              $blue[2] $grey[1] --bold
       set -x color_virtualgo                $blue[2] $grey[1] --bold
       set -x color_desk                     $blue[2] $grey[1] --bold
+      set -x color_currentos                $green $colorfg --bold
 
     case 'gruvbox'
       #               light  medium  dark  darkest
@@ -431,12 +450,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant               $blue[2] $fg[2] --bold
       set -x color_k8s                   $green[2] $fg[2] --bold
       set -x color_username              $fg[3] $blue[2] --bold
+      set -x color_root_username         $fg[3] $red --bold
       set -x color_hostname              $fg[3] $blue[2]
       set -x color_rvm                   $red[2] $fg[2] --bold
       set -x color_nvm                   $green[1] $fg[2] --bold
       set -x color_virtualfish           $blue[2] $fg[2] --bold
       set -x color_virtualgo             $blue[2] $fg[2] --bold
       set -x color_desk                  $blue[2] $fg[2] --bold
+      set -x color_currentos             $green $colorfg --bold
 
     case 'dracula' # https://draculatheme.com
       set -l bg           282a36
@@ -473,12 +494,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant               $pink $bg --bold
       set -x color_k8s                   $green $fg --bold
       set -x color_username              $selection $cyan --bold
+      set -x color_root_username         $selection $red --bold
       set -x color_hostname              $selection $cyan
       set -x color_rvm                   $red $bg --bold
       set -x color_nvm                   $green $bg --bold
       set -x color_virtualfish           $comment $bg --bold
       set -x color_virtualgo             $cyan $bg --bold
       set -x color_desk                  $comment $bg --bold
+      set -x color_currentos             $green $bg --bold
 
     case '*' # default dark theme
       #               light  medium dark
@@ -515,12 +538,14 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[2] $white --bold
       set -x color_username                 $grey[1] $blue[3] --bold
+      set -x color_root_username            $grey[1] $red[1] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold
       set -x color_nvm                      $green[1] $white --bold
       set -x color_virtualfish              $blue[2] $grey[1] --bold
       set -x color_virtualgo                $go_blue $black --bold
       set -x color_desk                     $blue[2] $grey[1] --bold
+      set -x color_currentos                $green $white --bold
   end
 end
 

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -56,6 +56,23 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
     set left_arrow_glyph        ''
   end
 
+  set os_type_darwin       'Mac'
+  set os_type_synology     'Syno'
+  set os_type_mint         'Mint'
+  set os_type_suse         'Suse'
+  set os_type_centos       'Cent'
+  set os_type_fedora       'Fed'
+  set os_type_redhat       'RHat'
+  set os_type_gentoo       'Gnto'
+  set os_type_arch         'Arch'
+  set os_type_alpine       'Alp'
+  set os_type_ubuntu       'Ubu'
+  set os_type_elementary   'Elem'
+  set os_type_debian       'Deb'
+  set os_type_generic      'Lin'
+  set os_type_amazon       'Amz'
+  set os_type_coreos       'Core'
+
   # Use prettier Nerd Fonts glyphs
   if [ "$theme_nerd_fonts" = "yes" ]
     set branch_glyph     \uF418
@@ -84,6 +101,24 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
     set git_plus_glyph       \uF0DE # fa-sort-asc
     set git_minus_glyph      \uF0DD # fa-sort-desc
     set git_plus_minus_glyph \uF0DC # fa-sort
+
+    set os_type_darwin       ''
+    set os_type_synology     ''
+    set os_type_mint         ''
+    set os_type_suse         ''
+    set os_type_centos       ''
+    set os_type_fedora       ''
+    set os_type_redhat       ''
+    set os_type_gentoo       ''
+    set os_type_arch         ''
+    set os_type_alpine       ''
+    set os_type_ubuntu       ''
+    set os_type_elementary   ''
+    set os_type_debian       ''
+    set os_type_generic      ''
+    set os_type_amazon       ''
+    set os_type_coreos       ''
+
   end
 
   # Avoid ambiguous glyphs


### PR DESCRIPTION
This commit includes these new features:

- *A segment which displays OS type.* This is especially useful
  if constantly logging into different computers with different
  systems and you need to know if you need to type `apk`, `apt`,
  `dnf`, or `yum`, for example. Enable it by setting the
  `theme_display_currentos` variable to `yes`.
- *Padlock for SSH connection.* You may enable the padlock by
  setting the `theme_display_ssh_keylock` to `yes`. Padlock is
  shown only when accessing the terminal via a SSH session.
  The padlock is displayed _before_ the hostname.
- *Split username and hostname segments.* This enable each segment
  to be coloured with a different background. Set
  `theme_display_split_user_hostname` to `yes` to enable this
  feature.
- *Color root username differently.* When logged in as a `root`
  user, background (or the color of the username) will change
  to red. New colour has been added to the theme(s) for this
  feature.