### PR TITLE
Add ranger indicator

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -851,6 +851,21 @@ function __bobthefish_prompt_virtualgo -S -d 'Display current Go virtual environ
     set_color normal
 end
 
+function __bobthefish_prompt_ranger -S -d 'Display current ranger indicator'
+    [ "$theme_display_ranger" = 'no' -o -z "$RANGER_LEVEL" ]
+    and return
+
+    __bobthefish_start_segment $color_ranger
+    echo -ns $ranger_glyph
+
+    if [ "$theme_display_ranger_level" = 'yes' ]
+        echo -ns "$RANGER_LEVEL"
+    end
+
+    echo -ns ' '
+    set_color normal
+end
+
 function __bobthefish_prompt_desk -S -d 'Display current desk environment'
     [ "$theme_display_desk" = 'no' -o -z "$DESK_ENV" ]
     and return
@@ -1077,6 +1092,7 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
     __bobthefish_prompt_rubies
     __bobthefish_prompt_virtualfish
     __bobthefish_prompt_virtualgo
+    __bobthefish_prompt_ranger
     __bobthefish_prompt_nvm
 
     set -l real_pwd (__bobthefish_pwd)

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -21,6 +21,7 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
 
   set -x ruby_glyph              ''
   set -x go_glyph                ''
+  set -x ranger_glyph            'R'
 
   # Desk glyphs
   set -x desk_glyph              \u25F2


### PR DESCRIPTION
Hello, I am using [ranger](https://github.com/ranger/ranger) which allows you to spawn a new terminal via shortcut `S`. The terminal will have `$RANGER_LEVEL` set, and it is advantageous to see if this shell is in ranger. 

**This PR implements:** ranger prompt indicator

There is possibility to show current `RANGER_LEVEL` in prompt setting `theme_display_ranger_level` to `yes`.