### PR TITLE
In the prompt, show user info before everything else

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1064,13 +1064,13 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
     __bobthefish_prompt_status $last_status
     __bobthefish_prompt_vi
 
+    # User / hostname info
+    __bobthefish_prompt_user
+
     # Containers and VMs
     __bobthefish_prompt_vagrant
     __bobthefish_prompt_docker
     __bobthefish_prompt_k8s_context
-
-    # User / hostname info
-    __bobthefish_prompt_user
 
     # Virtual environments
     __bobthefish_prompt_desk


### PR DESCRIPTION
Logically, if you're on a remote machine, all context information including k8s context and so on belongs to that machine since the SSH session is running on that machine. Therefore, the current user and hostname should be displayed first.