### PR TITLE
Escape project_root_dir before using it in regex

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -231,7 +231,8 @@ function __bobthefish_project_pwd -S -a project_root_dir -a real_pwd -d 'Print t
     set -q theme_project_dir_length
     or set -l theme_project_dir_length 0
 
-    set -l project_dir (string replace -r '^'"$project_root_dir"'($|/)' '' $real_pwd)
+    set -l project_root_dir_escaped (string escape --style=regex $project_root_dir)
+    set -l project_dir (string replace -r '^'"$project_root_dir_escaped"'($|/)' '' $real_pwd)
 
     if [ $theme_project_dir_length -eq 0 ]
         echo -n $project_dir


### PR DESCRIPTION
Fixes issue where paths containing parentheses would be shown **in ful**l to the right of the git "project root" symbol instead of showing only the **current subdirectory**.

Fixes #243 