### PR TITLE
Fix always displaying system ruby when set by asdf

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -781,7 +781,7 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
         or return
 
         # If asdf changes their ruby version provenance format, update this to match
-        [ "$asdf_provenance" = "(set by $HOME/.tool-versions)" ]
+        [ "$asdf_provenance" = "   (set by $HOME/.tool-versions)" ]
         and return
 
         set ruby_version $asdf_ruby_version

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -777,11 +777,11 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
     else if type -q chruby # chruby is implemented as a function, so omitting the -f is intentional
         set ruby_version $RUBY_VERSION
     else if type -fq asdf
-        asdf current ruby 2>/dev/null | read -l asdf_ruby_version asdf_provenance
+        asdf current ruby 2>/dev/null | tr -s " " | read -l asdf_ruby_version asdf_provenance
         or return
 
         # If asdf changes their ruby version provenance format, update this to match
-        [ "$asdf_provenance" = "   (set by $HOME/.tool-versions)" ]
+        [ "$asdf_provenance" = "(set by $HOME/.tool-versions)" ]
         and return
 
         set ruby_version $asdf_ruby_version

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -777,7 +777,7 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
     else if type -q chruby # chruby is implemented as a function, so omitting the -f is intentional
         set ruby_version $RUBY_VERSION
     else if type -fq asdf
-        asdf current ruby 2>/dev/null | string trim - l | read -l asdf_ruby_version asdf_provenance
+        asdf current ruby 2>/dev/null | read -l -t asdf_ruby_version asdf_provenance
         or return
 
         # If asdf changes their ruby version provenance format, update this to match

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -777,7 +777,7 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
     else if type -q chruby # chruby is implemented as a function, so omitting the -f is intentional
         set ruby_version $RUBY_VERSION
     else if type -fq asdf
-        asdf current ruby 2>/dev/null | tr -s " " | read -l asdf_ruby_version asdf_provenance
+        asdf current ruby 2>/dev/null | string trim - l | read -l asdf_ruby_version asdf_provenance
         or return
 
         # If asdf changes their ruby version provenance format, update this to match


### PR DESCRIPTION
Since the asdf-ruby integration with bobthefish was written, asdf has changed their ruby version provenance format.
`asdf current ruby 2>/dev/null | read -l asdf_ruby_version asdf_provenance` now results in 
```
$ echo $asdf_ruby_version
2.5.7
$ echo $asdf_provenance                                                                          
   (set by /Users/patrick.fong/.tool-versions)
```
Notice the extraneous 3 spaces in the beginning. The original asdf integration didn't expect that whitespace and so right now it's treating it as a non-system Ruby. And that results in the system ruby version always being displayed, which is annoying. 

This is a small patch to fix that. All I did was pipe the output through `tr -s` which removes the extra spaces. I've tested it locally to make sure it works. Thanks!