### PR TITLE
Do not display Kubernetes context and namespace if it's the defaults ones

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -625,6 +625,10 @@ function __bobthefish_prompt_k8s_context -S -d 'Show current Kubernetes context'
     [ "$theme_display_k8s_namespace" = 'yes' ]
     and set -l namespace (__bobthefish_k8s_namespace)
 
+    [ -z $context -o "$context" = 'default' ]
+    and [ -z $namespace -o "$namespace" = 'default' ]
+    and return
+
     set -l segment $k8s_glyph " " $context
     [ -n "$namespace" ]
     and set segment $segment ":" $namespace


### PR DESCRIPTION
Kubernetes context is always displayed even if we're using local Kubernetes instance and that's a little annoying :)