### PR TITLE
 Enable hiding default branch names other than 'master' 

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -24,6 +24,8 @@
 #     set -g theme_display_git_dirty_verbose yes
 #     set -g theme_display_git_stashed_verbose yes
 #     set -g theme_display_git_master_branch yes
+#     set -g theme_display_git_default_branch yes
+#     set -g theme_git_default_branch ''
 #     set -g theme_git_worktree_support yes
 #     set -g theme_display_vagrant yes
 #     set -g theme_display_docker_machine no

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -82,6 +82,10 @@ function __bobthefish_git_branch -S -d 'Get the current git branch (or commitish
         and echo $branch_glyph
         and return
 
+        [ "$theme_display_git_default_branch" != 'yes' -a "$ref" = "refs/heads/$theme_git_default_branch" ]
+        and echo $branch_glyph
+        and return
+
         # truncate the middle of the branch name, but only if it's 25+ characters
         set -l truncname $ref
         [ "$theme_use_abbreviated_branch_name" = 'yes' ]


### PR DESCRIPTION
I am currently using the `theme_display_git_master_branch` feature to hide the default branch in git repositories. I would like to be able to use that feature even when choosing a different name for that branch such as `main`.

To that end, this pull-request introduces a new flag `theme_display_git_default_branch`, which does the same as the existing feature for the branch name set in `$theme_git_default_branch`.