### PR TITLE
Move Kubernetes prompt color into a function

### DIFF
--- a/functions/__bobthefish_prompt_k8s_color.fish
+++ b/functions/__bobthefish_prompt_k8s_color.fish
@@ -1,0 +1,5 @@
+function __bobthefish_prompt_k8s_color -S -d 'Determine Kubernetes prompt color based on the current context and namespace'
+    for i in $color_k8s
+        echo $i
+    end
+end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -645,10 +645,9 @@ function __bobthefish_prompt_k8s_context -S -d 'Show current Kubernetes context'
     [ -n "$namespace" ]
     and set segment $segment ':' $namespace
 
-    __bobthefish_start_segment $color_k8s
+    __bobthefish_start_segment (__bobthefish_prompt_k8s_color $context $namespace)
     echo -ns $segment ' '
 end
-
 
 # ==============================
 # Cloud Tools

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -637,12 +637,8 @@ function __bobthefish_prompt_k8s_context -S -d 'Show current Kubernetes context'
     [ "$theme_display_k8s_namespace" = 'yes' ]
     and set -l namespace (__bobthefish_k8s_namespace)
 
-    [ -z $context -o "$context" = 'default' ]
-    and [ -z $namespace -o "$namespace" = 'default' ]
-    and return
-
     set -l segment $k8s_glyph ' ' $context
-    [ -n "$namespace" ]
+    [ -n "$namespace" -a "$namespace" != 'default' ]
     and set segment $segment ':' $namespace
 
     __bobthefish_start_segment (__bobthefish_prompt_k8s_color $context $namespace)


### PR DESCRIPTION
This patch extracts the logic of determining the Kubernetes prompt color to a separate function that a user can override based on their cluster naming.

For example, the following could be added to `~/.config/fish/config.fish`:
```fish
function __bobthefish_prompt_k8s_color -S
    set -l color $color_k8s

    switch $argv[1]
    case "*prod"
        set color red white --bold
    case "*stage"
        set color yellow white --bold
    end

    for i in $color
        echo $i
    end
end
```
It's required that the default implementation of the `__bobthefish_prompt_k8s_color` function is declared in its own file and is autoloadable. This way, the user-defined function, if exists, will be declared first and prevent autoloading of the default implementation.