### PR TITLE
Add support for AWS Vault segment in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `yes` to show the indicator.
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).
 - `theme_display_k8s_namespace`. This feature is disabled by default. Use `yes` to show the current kubernetes namespace.
+- `theme_display_aws_vault_profile`. This feature is disabled by default. Use `yes` to show the currently executing AWS Vault profile.
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_display_sudo_user`. If set to `yes`, displays the sudo-username in a root shell. For example, when calling `sudo -s` and having this option set to `yes`, the username of the user, who called `sudo -s`, will be displayed.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -29,6 +29,7 @@
 #     set -g theme_display_docker_machine no
 #     set -g theme_display_k8s_context yes
 #     set -g theme_display_k8s_namespace no
+#     set -g theme_display_aws_vault_profile yes
 #     set -g theme_display_hg yes
 #     set -g theme_display_virtualenv no
 #     set -g theme_display_nix no
@@ -645,6 +646,32 @@ end
 
 
 # ==============================
+# Cloud Tools
+# ==============================
+
+function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
+    [ "$theme_display_aws_vault_profile" = 'yes' ]
+    or return
+
+    [ -n "$AWS_VAULT" ]
+    or return
+
+    set -l profile $AWS_VAULT
+
+    set -l now (date --utc +%s)
+    set -l expiry (date -d "$AWS_SESSION_EXPIRATION" +%s)
+    set -l diff_mins (math "floor(( $expiry - $now ) / 60)")
+    [ "$diff_mins" -lt 0 ]
+    and set -l diff_mins 0
+
+    set -l segment $profile " (" $diff_mins "m)"
+
+    __bobthefish_start_segment $color_desk
+    echo -ns $segment " "
+end
+
+
+# ==============================
 # User / hostname info segments
 # ==============================
 
@@ -1075,6 +1102,9 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
     __bobthefish_prompt_vagrant
     __bobthefish_prompt_docker
     __bobthefish_prompt_k8s_context
+
+    # Cloud Tools
+    __bobthefish_prompt_aws_vault_profile
 
     # Virtual environments
     __bobthefish_prompt_nix

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -664,7 +664,7 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     [ "$diff_mins" -lt 0 ]
     and set -l diff_mins 0
 
-    set -l segment $profile " (" $diff_mins "m)"
+    set -l segment $aws_vault_glyph " " $profile " (" $diff_mins "m)"
 
     __bobthefish_start_segment $color_desk
     echo -ns $segment " "

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -664,7 +664,7 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     [ "$diff_mins" -lt 0 ]
     and set -l diff_mins 0
 
-    set -l segment $aws_vault_glyph " " $profile " (" $diff_mins "m)"
+    set -l segment $profile " (" $diff_mins "m)"
 
     __bobthefish_start_segment $color_aws_vault
     echo -ns $segment " "

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -653,7 +653,7 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     [ "$theme_display_aws_vault_profile" = 'yes' ]
     or return
 
-    [ -n "$AWS_VAULT" ]
+    [ -n "$AWS_VAULT" -a -n "$AWS_SESSION_EXPIRATION" ]
     or return
 
     set -l profile $AWS_VAULT

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -666,7 +666,7 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
 
     set -l segment $aws_vault_glyph " " $profile " (" $diff_mins "m)"
 
-    __bobthefish_start_segment $color_desk
+    __bobthefish_start_segment $color_aws_vault
     echo -ns $segment " "
 end
 

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -28,7 +28,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
-      set -x color_aws_vault                magenta white --bold
+      set -x color_aws_vault                yellow $colorfg --bold
       set -x color_username                 white black --bold
       set -x color_hostname                 white black
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -62,7 +62,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
-      set -x color_aws_vault                magenta white --bold
+      set -x color_aws_vault                yellow $colorfg --bold
       set -x color_username                 black white --bold
       set -x color_hostname                 black white
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -96,7 +96,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
-      set -x color_aws_vault                magenta white --bold
+      set -x color_aws_vault                yellow $colorfg --bold
       set -x color_username                 brgrey white --bold
       set -x color_hostname                 brgrey white
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -130,7 +130,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
-      set -x color_aws_vault                magenta white --bold
+      set -x color_aws_vault                yellow $colorfg --bold
       set -x color_username                 grey black --bold
       set -x color_hostname                 grey black
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -170,7 +170,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue $green --bold
       set -x color_k8s                      $green $white --bold
-      set -x color_aws_vault                $green $white --bold
+      set -x color_aws_vault                $yellow $grey --bold
       set -x color_username                 $grey $blue --bold
       set -x color_hostname                 $grey $blue
       set -x color_rvm                      $red $grey --bold
@@ -221,7 +221,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base06 $colorfg --bold
-      set -x color_aws_vault                $base06 $colorfg --bold
+      set -x color_aws_vault                $base09 $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
@@ -272,7 +272,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base0B $colorfg --bold
-      set -x color_aws_vault                $base0B $colorfg --bold
+      set -x color_aws_vault                $base09 $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
@@ -323,7 +323,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
-      set -x color_aws_vault                $green $colorfg --bold
+      set -x color_aws_vault                $yellow $colorfg --bold
       set -x color_username                 $base2 $blue --bold
       set -x color_hostname                 $base2 $blue
       set -x color_rvm                      $red $colorfg --bold
@@ -374,7 +374,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
-      set -x color_aws_vault                $green $colorfg --bold
+      set -x color_aws_vault                $yellow $colorfg --bold
       set -x color_username                 $base02 $blue --bold
       set -x color_hostname                 $base02 $blue
       set -x color_rvm                      $red $colorfg --bold
@@ -418,7 +418,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[1] $colorfg --bold
-      set -x color_aws_vault                $green[1] $colorfg --bold
+      set -x color_aws_vault                $orange[1] $orange[3] --bold
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold
@@ -461,7 +461,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue[2] $fg[2] --bold
       set -x color_k8s                      $green[2] $fg[2] --bold
-      set -x color_aws_vault                $green[2] $fg[2] --bold
+      set -x color_aws_vault                $yellow[1] $bg[1] --bold
       set -x color_username                 $fg[3] $blue[2] --bold
       set -x color_hostname                 $fg[3] $blue[2]
       set -x color_rvm                      $red[2] $fg[2] --bold
@@ -506,7 +506,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $pink $bg --bold
       set -x color_k8s                      $green $fg --bold
-      set -x color_aws_vault                $green $fg --bold
+      set -x color_aws_vault                $yellow $bg --bold
       set -x color_username                 $selection $cyan --bold
       set -x color_hostname                 $selection $cyan
       set -x color_rvm                      $red $bg --bold
@@ -557,7 +557,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $base02 $colorfg --bold
       set -x color_k8s                      $base02 $colorfg --bold
-      set -x color_aws_vault                $base02 $colorfg --bold
+      set -x color_aws_vault                $base0D $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base09 $colorfg --bold
@@ -601,7 +601,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[2] $white --bold
-      set -x color_aws_vault                $green[2] $white --bold
+      set -x color_aws_vault                $orange[1] $orange[3] --bold
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -28,6 +28,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
+      set -x color_aws_vault                magenta white --bold
       set -x color_username                 white black --bold
       set -x color_hostname                 white black
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -61,6 +62,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
+      set -x color_aws_vault                magenta white --bold
       set -x color_username                 black white --bold
       set -x color_hostname                 black white
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -94,6 +96,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
+      set -x color_aws_vault                magenta white --bold
       set -x color_username                 brgrey white --bold
       set -x color_hostname                 brgrey white
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -127,6 +130,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
+      set -x color_aws_vault                magenta white --bold
       set -x color_username                 grey black --bold
       set -x color_hostname                 grey black
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -166,6 +170,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue $green --bold
       set -x color_k8s                      $green $white --bold
+      set -x color_aws_vault                $green $white --bold
       set -x color_username                 $grey $blue --bold
       set -x color_hostname                 $grey $blue
       set -x color_rvm                      $red $grey --bold
@@ -216,6 +221,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base06 $colorfg --bold
+      set -x color_aws_vault                $base06 $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
@@ -266,6 +272,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base0B $colorfg --bold
+      set -x color_aws_vault                $base0B $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
@@ -316,6 +323,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
+      set -x color_aws_vault                $green $colorfg --bold
       set -x color_username                 $base2 $blue --bold
       set -x color_hostname                 $base2 $blue
       set -x color_rvm                      $red $colorfg --bold
@@ -366,6 +374,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
+      set -x color_aws_vault                $green $colorfg --bold
       set -x color_username                 $base02 $blue --bold
       set -x color_hostname                 $base02 $blue
       set -x color_rvm                      $red $colorfg --bold
@@ -409,6 +418,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[1] $colorfg --bold
+      set -x color_aws_vault                $green[1] $colorfg --bold
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold
@@ -451,6 +461,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue[2] $fg[2] --bold
       set -x color_k8s                      $green[2] $fg[2] --bold
+      set -x color_aws_vault                $green[2] $fg[2] --bold
       set -x color_username                 $fg[3] $blue[2] --bold
       set -x color_hostname                 $fg[3] $blue[2]
       set -x color_rvm                      $red[2] $fg[2] --bold
@@ -495,6 +506,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $pink $bg --bold
       set -x color_k8s                      $green $fg --bold
+      set -x color_aws_vault                $green $fg --bold
       set -x color_username                 $selection $cyan --bold
       set -x color_hostname                 $selection $cyan
       set -x color_rvm                      $red $bg --bold
@@ -545,6 +557,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $base02 $colorfg --bold
       set -x color_k8s                      $base02 $colorfg --bold
+      set -x color_aws_vault                $base02 $colorfg --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base09 $colorfg --bold
@@ -588,6 +601,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[2] $white --bold
+      set -x color_aws_vault                $green[2] $white --bold
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -30,9 +30,6 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
   # Kubernetes glyphs
   set -x k8s_glyph               \u2388 # '⎈'
 
-  # AWS glyphs
-  set -x aws_vault_glyph         \u2601 # '☁'
-
   # Vagrant glyphs
   set -x vagrant_running_glyph   \u2191 # ↑ 'running'
   set -x vagrant_poweroff_glyph  \u2193 # ↓ 'poweroff'

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -30,6 +30,9 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
   # Kubernetes glyphs
   set -x k8s_glyph               \u2388 # '⎈'
 
+  # AWS glyphs
+  set -x aws_vault_glyph         \u2601 # '☁'
+
   # Vagrant glyphs
   set -x vagrant_running_glyph   \u2191 # ↑ 'running'
   set -x vagrant_poweroff_glyph  \u2193 # ↓ 'poweroff'

--- a/functions/bobthefish_display_colors.fish
+++ b/functions/bobthefish_display_colors.fish
@@ -142,7 +142,7 @@ function bobthefish_display_colors -a color_scheme -d 'Print example prompt colo
   __bobthefish_finish_segments
 
   __bobthefish_start_segment $color_aws_vault
-  echo -ns $aws_vault_glyph ' aws-vault '
+  echo -ns aws-vault ' '
   __bobthefish_finish_segments
 
   echo -e "\n"

--- a/functions/bobthefish_display_colors.fish
+++ b/functions/bobthefish_display_colors.fish
@@ -141,5 +141,9 @@ function bobthefish_display_colors -a color_scheme -d 'Print example prompt colo
   echo -ns $desk_glyph desk ' '
   __bobthefish_finish_segments
 
+  __bobthefish_start_segment $color_aws_vault
+  echo -ns $aws_vault_glyph ' aws-vault '
+  __bobthefish_finish_segments
+
   echo -e "\n"
 end


### PR DESCRIPTION
Hey there - couldn't see a contributing doc or any rules so I hope a drive-by PR is OK.

Looking to add support for a popular AWS credentials manager called [AWS Vault](https://github.com/99designs/aws-vault). In particular, this PR adds a segment with the name of the profile being executed/used and the expiry time.

Requires that you set the `theme_display_aws_vault_profile` var to `yes` as is the pattern with many other theme vars.

![image](https://user-images.githubusercontent.com/14284827/92436052-db7f7180-f1f7-11ea-8184-b9ee44168b02.png)

Certainly not perfectly polished just yet, but wanted to get some feedback on what could be improved here. Would love to see this as a part of the theme sometime soon!