### PR TITLE
use system timezone as default

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -48,7 +48,12 @@
 #     set -g fish_prompt_pwd_dir_length 0
 #     set -g theme_project_dir_length 1
 #     set -g theme_newline_cursor yes
+#     set -g theme_date_timezone America/Los_Angeles
 
+set -g theme_date_format "+%a %H:%M"
+set -g theme_color_scheme solarized
+set -g fish_prompt_pwd_dir_length 4
+set -g theme_nerd_fonts yes
 
 # ==============================
 # Helper methods

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -63,7 +63,9 @@ function __bobthefish_timestamp -S -d 'Show the current timestamp'
     or set -l theme_date_format "+%c"
 
     echo -n ' '
-    env TZ="$theme_date_timezone" date $theme_date_format
+    set -q theme_date_timezone
+        and env TZ="$theme_date_timezone" date $theme_date_format
+        or date $theme_date_format
 end
 
 function fish_right_prompt -d 'bobthefish is all about the right prompt'


### PR DESCRIPTION
When *theme_date_timezone* is not set, date is displayed as UTC date instead of current system timezone.

This update will check if *theme_date_timezone* is set before setting TZ variable.