### PR TITLE
Fix nord colorscheme for exit, su, jobs segments

### DIFF
--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -524,10 +524,10 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -l colorfg $base00
 
-      set -x color_initial_segment_exit     $base05 $base0B --bold  
+      set -x color_initial_segment_exit     $base05 $base0B --bold
       set -x color_initial_segment_private  $base05 $base02
-      set -x color_initial_segment_su       $base05 $base0E --bold 
-      set -x color_initial_segment_jobs     $base05 $base0C --bold 
+      set -x color_initial_segment_su       $base05 $base0E --bold
+      set -x color_initial_segment_jobs     $base05 $base0C --bold
 
       set -x color_path                     $base02 $base05
       set -x color_path_basename            $base02 $base06 --bold

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -524,10 +524,10 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -l colorfg $base00
 
-      set -x color_initial_segment_exit     $base05 $base08 --bold
+      set -x color_initial_segment_exit     $base05 $base0B --bold  
       set -x color_initial_segment_private  $base05 $base02
-      set -x color_initial_segment_su       $base05 $base0B --bold
-      set -x color_initial_segment_jobs     $base08 $base0D --bold
+      set -x color_initial_segment_su       $base05 $base0E --bold 
+      set -x color_initial_segment_jobs     $base05 $base0C --bold 
 
       set -x color_path                     $base02 $base05
       set -x color_path_basename            $base02 $base06 --bold


### PR DESCRIPTION
This PR fixes the IMO broken colors of the `exit`, `su`, and `jobs` segments in the nord color scheme as described in #234.  
I've been using these colors for a while now and find them much more suitable than the original ones.
