### PR TITLE
Support for Git default branches other than master

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ set -g theme_project_dir_length 1
 set -g theme_newline_cursor yes
 set -g theme_newline_prompt '$ '
 ```
+**GIT options**
+
+Note that `master` and `main` now behave in the same way i.e. they
+are hidden/collapsed by default. Set the `theme_display_git_master_branch`
+override to `yes` (see above) to see these branches.
 
 **Title options**
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ set -g theme_display_git_untracked no
 set -g theme_display_git_ahead_verbose yes
 set -g theme_display_git_dirty_verbose yes
 set -g theme_display_git_stashed_verbose yes
-set -g theme_display_git_master_branch yes
+set -g theme_display_git_default_branch yes
+set -g theme_git_default_branches master main
 set -g theme_git_worktree_support yes
 set -g theme_use_abbreviated_branch_name yes
 set -g theme_display_vagrant yes
@@ -108,11 +109,10 @@ set -g theme_project_dir_length 1
 set -g theme_newline_cursor yes
 set -g theme_newline_prompt '$ '
 ```
-**GIT options**
+**Git options**
 
-Note that `master` and `main` now behave in the same way i.e. they
-are hidden/collapsed by default. Set the `theme_display_git_master_branch`
-override to `yes` (see above) to see these branches.
+- `theme_display_git_default_branch`. By default theme will hide/collapse the branch name in your prompt when you are using a Git _default branch_ i.e. historically `master` and often `main` now. Set to `yes` to stop these branches from being hidden/collapsed.
+- `theme_git_default_branches`. The big cloud repos (GitHub, Bitbucket, GitLab et al.) are moving away from using `master` as the default branch name, and allow you to choose your own. As of version **2.28**, Git also supports custom default branch names via the `init.defaultBranch` config option. If our defaults of `master main` don't suit you, you can add/remove names in thist list i.e. `main trunk`. This ensures correct hiding/collapsing behaviour with custom default branch names (unless option above is activated).
 
 **Title options**
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -76,7 +76,7 @@ function __bobthefish_escape_regex -a str -d 'A backwards-compatible `string esc
 end
 
 function __bobthefish_git_branch -S -d 'Get the current git branch (or commitish)'
-    set -l branch (command git symbolic-ref HEAD | cut -d "/" -f3 2>/dev/null)
+    set -l branch (command git symbolic-ref HEAD | string replace -r '^refs/heads/' '' 2>/dev/null)
     and begin
         [ -n "$theme_git_default_branches" ]
         or set -l theme_git_default_branches master main

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -78,7 +78,7 @@ end
 function __bobthefish_git_branch -S -d 'Get the current git branch (or commitish)'
     set -l ref (command git symbolic-ref HEAD 2>/dev/null)
     and begin
-        [ "$theme_display_git_master_branch" != 'yes' -a "$ref" = 'refs/heads/master' ]
+        [ "$theme_display_git_master_branch" != 'yes' -a \( "$ref" = 'refs/heads/master' -o "$ref" = 'refs/heads/main' \) ]
         and echo $branch_glyph
         and return
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -81,7 +81,7 @@ function __bobthefish_git_branch -S -d 'Get the current git branch (or commitish
         [ -n "$theme_git_default_branches" ]
         or set -l theme_git_default_branches master main
 
-        [ "$theme_display_git_master_branch" != 'yes' ]
+        [ "$theme_display_git_master_branch" != 'yes' -a "$theme_display_git_default_branch" != 'yes' ]
         and contains $branch $theme_git_default_branches
         and echo $branch_glyph
         and return

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -23,7 +23,8 @@
 #     set -g theme_display_git_ahead_verbose yes
 #     set -g theme_display_git_dirty_verbose yes
 #     set -g theme_display_git_stashed_verbose yes
-#     set -g theme_display_git_master_branch yes
+#     set -g theme_display_git_default_branch yes
+#     set -g theme_git_default_branches main trunk
 #     set -g theme_git_worktree_support yes
 #     set -g theme_display_vagrant yes
 #     set -g theme_display_docker_machine no

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -76,9 +76,13 @@ function __bobthefish_escape_regex -a str -d 'A backwards-compatible `string esc
 end
 
 function __bobthefish_git_branch -S -d 'Get the current git branch (or commitish)'
+    [ -n "$theme_git_default_branches" ]
+    or set -l theme_git_default_branches refs/heads/master refs/heads/main
+
     set -l ref (command git symbolic-ref HEAD 2>/dev/null)
     and begin
-        [ "$theme_display_git_master_branch" != 'yes' -a \( "$ref" = 'refs/heads/master' -o "$ref" = 'refs/heads/main' \) ]
+        [ "$theme_display_git_master_branch" != 'yes' ]
+        and contains $ref $theme_git_default_branches
         and echo $branch_glyph
         and return
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -76,22 +76,22 @@ function __bobthefish_escape_regex -a str -d 'A backwards-compatible `string esc
 end
 
 function __bobthefish_git_branch -S -d 'Get the current git branch (or commitish)'
-    [ -n "$theme_git_default_branches" ]
-    or set -l theme_git_default_branches refs/heads/master refs/heads/main
-
-    set -l ref (command git symbolic-ref HEAD 2>/dev/null)
+    set -l branch (command git symbolic-ref HEAD | cut -d "/" -f3 2>/dev/null)
     and begin
+        [ -n "$theme_git_default_branches" ]
+        or set -l theme_git_default_branches master main
+
         [ "$theme_display_git_master_branch" != 'yes' ]
-        and contains $ref $theme_git_default_branches
+        and contains $branch $theme_git_default_branches
         and echo $branch_glyph
         and return
 
         # truncate the middle of the branch name, but only if it's 25+ characters
-        set -l truncname $ref
+        set -l truncname $branch
         [ "$theme_use_abbreviated_branch_name" = 'yes' ]
-        and set truncname (string replace -r '^(.{28}).{3,}(.{5})$' "\$1…\$2" $ref)
+        and set truncname (string replace -r '^(.{17}).{3,}(.{5})$' "\$1…\$2" $branch)
 
-        string replace -r '^refs/heads/' "$branch_glyph " $truncname
+        echo $branch_glyph $truncname
         and return
     end
 


### PR DESCRIPTION
Newly created repos in GitHub [now use](https://github.blog/changelog/2020-08-26-set-the-default-branch-for-newly-created-repositories/) `main` as the default branch name. This PR makes `main` behave the same as `master` would (i.e. collapsed by default).

I'm not supporting the gazillions of other default branch names that other devs might use; I think that keeping `master` and `main` as the core names is the simplest and least-controversial approach.