### PR TITLE
Improve AWS Vault segment with better session time format and expiration warning

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -669,8 +669,11 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     and set -l diff_time (math "floor($diff_mins / 60)")"h"(math "$diff_mins % 60")"m"
 
     set -l segment $profile " (" $diff_time ")"
+    set -l status_color $color_aws_vault
+    [ $diff_mins -le 0 ]
+    and set -l status_color $color_aws_vault_expired
 
-    __bobthefish_start_segment $color_aws_vault
+    __bobthefish_start_segment $status_color
     echo -ns $segment " "
 end
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -661,10 +661,14 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     set -l now (date --utc +%s)
     set -l expiry (date -d "$AWS_SESSION_EXPIRATION" +%s)
     set -l diff_mins (math "floor(( $expiry - $now ) / 60)")
-    [ "$diff_mins" -lt 0 ]
-    and set -l diff_mins 0
 
-    set -l segment $profile " (" $diff_mins "m)"
+    set -l diff_time $diff_mins"m"
+    [ $diff_mins -le 0 ]
+    and set -l diff_time "0m"
+    [ $diff_mins -ge 60 ]
+    and set -l diff_time (math "floor($diff_mins / 60)")"h"(math "$diff_mins % 60")"m"
+
+    set -l segment $profile " (" $diff_time ")"
 
     __bobthefish_start_segment $color_aws_vault
     echo -ns $segment " "

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -29,6 +29,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_aws_vault                blue $colorfg --bold
+      set -x color_aws_vault_expired        blue red --bold
       set -x color_username                 white black --bold
       set -x color_hostname                 white black
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -63,6 +64,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_aws_vault                blue $colorfg --bold
+      set -x color_aws_vault_expired        blue red --bold
       set -x color_username                 black white --bold
       set -x color_hostname                 black white
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -97,6 +99,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_aws_vault                blue $colorfg --bold
+      set -x color_aws_vault_expired        blue red --bold
       set -x color_username                 brgrey white --bold
       set -x color_hostname                 brgrey white
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -131,6 +134,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  brcyan $colorfg
       set -x color_k8s                      magenta white --bold
       set -x color_aws_vault                blue $colorfg --bold
+      set -x color_aws_vault_expired        blue red --bold
       set -x color_username                 grey black --bold
       set -x color_hostname                 grey black
       set -x color_rvm                      brmagenta $colorfg --bold
@@ -171,6 +175,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $blue $green --bold
       set -x color_k8s                      $green $white --bold
       set -x color_aws_vault                $blue $grey --bold
+      set -x color_aws_vault_expired        $blue $red --bold
       set -x color_username                 $grey $blue --bold
       set -x color_hostname                 $grey $blue
       set -x color_rvm                      $red $grey --bold
@@ -222,6 +227,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base06 $colorfg --bold
       set -x color_aws_vault                $base0D $colorfg --bold
+      set -x color_aws_vault_expired        $base0D $base08 --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
@@ -273,6 +279,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $base0C $colorfg --bold
       set -x color_k8s                      $base0B $colorfg --bold
       set -x color_aws_vault                $base0D $base0A --bold
+      set -x color_aws_vault_expired        $base0D $base08 --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base08 $colorfg --bold
@@ -324,6 +331,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
       set -x color_aws_vault                $violet $base3 --bold
+      set -x color_aws_vault_expired        $violet $orange --bold
       set -x color_username                 $base2 $blue --bold
       set -x color_hostname                 $base2 $blue
       set -x color_rvm                      $red $colorfg --bold
@@ -375,6 +383,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $violet $colorfg --bold
       set -x color_k8s                      $green $colorfg --bold
       set -x color_aws_vault                $violet $base3 --bold
+      set -x color_aws_vault_expired        $violet $orange --bold
       set -x color_username                 $base02 $blue --bold
       set -x color_hostname                 $base02 $blue
       set -x color_rvm                      $red $colorfg --bold
@@ -419,6 +428,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[1] $colorfg --bold
       set -x color_aws_vault                $blue[3] $orange[1] --bold
+      set -x color_aws_vault_expired        $blue[3] $red[3] --bold
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold
@@ -462,6 +472,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $blue[2] $fg[2] --bold
       set -x color_k8s                      $green[2] $fg[2] --bold
       set -x color_aws_vault                $blue[2] $yellow[1] --bold
+      set -x color_aws_vault_expired        $blue[2] $red[1] --bold
       set -x color_username                 $fg[3] $blue[2] --bold
       set -x color_hostname                 $fg[3] $blue[2]
       set -x color_rvm                      $red[2] $fg[2] --bold
@@ -507,6 +518,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $pink $bg --bold
       set -x color_k8s                      $green $fg --bold
       set -x color_aws_vault                $comment $yellow --bold
+      set -x color_aws_vault_expired        $comment $red --bold
       set -x color_username                 $selection $cyan --bold
       set -x color_hostname                 $selection $cyan
       set -x color_rvm                      $red $bg --bold
@@ -558,6 +570,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $base02 $colorfg --bold
       set -x color_k8s                      $base02 $colorfg --bold
       set -x color_aws_vault                $base0A $base0D --bold
+      set -x color_aws_vault_expired        $base0A $base0B --bold
       set -x color_username                 $base02 $base0D --bold
       set -x color_hostname                 $base02 $base0D
       set -x color_rvm                      $base09 $colorfg --bold
@@ -602,6 +615,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[2] $white --bold
       set -x color_aws_vault                $blue[3] $orange[1] --bold
+      set -x color_aws_vault_expired        $blue[3] $red[3] --bold
       set -x color_username                 $grey[1] $blue[3] --bold
       set -x color_hostname                 $grey[1] $blue[3]
       set -x color_rvm                      $ruby_red $grey[1] --bold

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -682,6 +682,8 @@ function __bobthefish_user_color_scheme_deprecated
   set -x color_vi_mode_insert           $__color_vi_mode_insert
   set -x color_vi_mode_visual           $__color_vi_mode_visual
   set -x color_vagrant                  $__color_vagrant
+  set -x color_aws_vault                $__color_aws_vault
+  set -x color_aws_vault_expired        $__color_aws_vault_expired
   set -x color_username                 $__color_username
   set -x color_hostname                 $__color_hostname
   set -x color_rvm                      $__color_rvm

--- a/functions/bobthefish_display_colors.fish
+++ b/functions/bobthefish_display_colors.fish
@@ -142,11 +142,11 @@ function bobthefish_display_colors -a color_scheme -d 'Print example prompt colo
   __bobthefish_finish_segments
 
   __bobthefish_start_segment $color_aws_vault
-  echo -ns aws-vault active ' '
+  echo -ns aws-vault ' (' active ') '
   __bobthefish_finish_segments
 
   __bobthefish_start_segment $color_aws_vault_expired
-  echo -ns aws-vault expired ' '
+  echo -ns aws-vault ' (' expired ') '
   __bobthefish_finish_segments
 
   echo -e "\n"

--- a/functions/bobthefish_display_colors.fish
+++ b/functions/bobthefish_display_colors.fish
@@ -142,7 +142,11 @@ function bobthefish_display_colors -a color_scheme -d 'Print example prompt colo
   __bobthefish_finish_segments
 
   __bobthefish_start_segment $color_aws_vault
-  echo -ns aws-vault ' '
+  echo -ns aws-vault active ' '
+  __bobthefish_finish_segments
+
+  __bobthefish_start_segment $color_aws_vault_expired
+  echo -ns aws-vault expired ' '
   __bobthefish_finish_segments
 
   echo -e "\n"


### PR DESCRIPTION
The AWS-Vault support added recently rendered session times > 60 mins in minutes only i.e. `702m`. Didn't think this was particularly acceptable/usable, but didn't want to derail the last PR (#266), so adding as a separate PR now.

Also, when it's expired, the segment will now change colour to show.



**Colours:**

![image](https://user-images.githubusercontent.com/14284827/96360949-0d341280-117e-11eb-863d-bc0da9e5d7e3.png)
![image](https://user-images.githubusercontent.com/14284827/96360956-18873e00-117e-11eb-8191-39cff86b88d9.png)
![image](https://user-images.githubusercontent.com/14284827/96360960-2341d300-117e-11eb-9824-373fefe85a27.png)
