### PR TITLE
Update check for nvm to allow for functions

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -902,7 +902,7 @@ function __bobthefish_prompt_node -S -d 'Display current node version'
     set -l node_manager
     set -l node_manager_dir
 
-    if type -fq nvm
+    if type -q nvm
       set node_manager 'nvm'
       set node_manager_dir $NVM_DIR
     else if type -fq fnm


### PR DESCRIPTION
After the latest change allowing for NVM or FNM, my prompt decorations for NVM are broken. 

I use https://github.com/FabioAntunes/fish-nvm and have used methods like https://eshlox.net/2019/01/27/how-to-use-nvm-with-fish-shell to get NVM to play nice with Fish and Bob The Fish. Using the `-f` flag on type means these methods are not able to determine when NVM is being used. 

I'm not sure this is the best way to get prompt functionality back -- but it solves the issue of ignoring NVM declared as a function. 