### PR TITLE
Add support for awsume on MacOS and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ You will need a [Powerline-patched font][btf-patching] for this to work, unless 
 
 This theme is based loosely on [agnoster][btf-agnoster].
 
+For MacOS install coreutils to get gdate as date has a different syntax. This is required for aws-vault and awsume support in the bobthefish prompt on MacOS. 
 
+    brew intall coreutils
+    
 ### Features
 
  * A helpful, but not too distracting, greeting.
@@ -130,6 +133,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).
 - `theme_display_k8s_namespace`. This feature is disabled by default. Use `yes` to show the current kubernetes namespace.
 - `theme_display_aws_vault_profile`. This feature is disabled by default. Use `yes` to show the currently executing [AWS Vault](https://github.com/99designs/aws-vault) profile.
+- `theme_display_awsume_profile`. This feature is disabled by default. Use `yes` to show the currently executing awsume profile.
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_display_sudo_user`. If set to `yes`, displays the sudo-username in a root shell. For example, when calling `sudo -s` and having this option set to `yes`, the username of the user, who called `sudo -s`, will be displayed.

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -31,6 +31,7 @@
 #     set -g theme_display_k8s_context yes
 #     set -g theme_display_k8s_namespace no
 #     set -g theme_display_aws_vault_profile yes
+#     set -g theme_display_awsume_profile yes
 #     set -g theme_display_hg yes
 #     set -g theme_display_virtualenv no
 #     set -g theme_display_nix no
@@ -682,6 +683,38 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     echo -ns $segment ' '
 end
 
+function __bobthefish_prompt_awsume_profile -S -d 'Show awsume profile'
+    [ "$theme_display_awsume_profile" = 'yes' ]
+    or return
+
+    [ -n "$AWSUME_PROFILE" -a -n "$AWSUME_EXPIRATION" ]
+    or return
+
+    if test (uname) = Darwin
+           set  now (gdate --utc +%s)
+           set  expiry (gdate -d "$AWSUME_EXPIRATION" +%s)
+    else
+           set  now (date --utc +%s)
+           set  expiry (date -d "$AWSUME_EXPIRATION" +%s)
+    end
+    set -l profile $AWSUME_PROFILE
+
+    set -l diff_mins (math "floor(( $expiry - $now ) / 60)")
+
+    set -l diff_time $diff_mins"m"
+    [ $diff_mins -le 0 ]
+    and set -l diff_time '0m'
+    [ $diff_mins -ge 60 ]
+    and set -l diff_time (math "floor($diff_mins / 60)")"h"(math "$diff_mins % 60")"m"
+
+    set -l segment $profile ' (' $diff_time ')'
+    set -l status_color $color_aws_vault
+    [ $diff_mins -le 0 ]
+    and set -l status_color $color_aws_vault_expired
+
+    __bobthefish_start_segment $status_color
+    echo -ns $segment ' '
+end
 
 # ==============================
 # User / hostname info segments
@@ -1134,6 +1167,7 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
 
     # Cloud Tools
     __bobthefish_prompt_aws_vault_profile
+    __bobthefish_prompt_awsume_profile
 
     # Virtual environments
     __bobthefish_prompt_nix

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -662,10 +662,15 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     [ -n "$AWS_VAULT" -a -n "$AWS_SESSION_EXPIRATION" ]
     or return
 
+    if test (uname) = Darwin
+           set  now (gdate --utc +%s)
+           set  expiry (gdate -d "$AWS_SESSION_EXPIRATION" +%s)
+    else
+           set  now (date --utc +%s)
+           set  expiry (date -d "$AWS_SESSION_EXPIRATION" +%s)
+    end
+    
     set -l profile $AWS_VAULT
-
-    set -l now (date --utc +%s)
-    set -l expiry (date -d "$AWS_SESSION_EXPIRATION" +%s)
     set -l diff_mins (math "floor(( $expiry - $now ) / 60)")
 
     set -l diff_time $diff_mins"m"


### PR DESCRIPTION
This PR adds support for showing the active awsume profile. Also it adds a check to use gdate (from coreutils) on MacOS as the data command on MacOS has a different syntax. The README is updated to reflect this. 

The awsume function re-uses the color scheme set for aws-vault. 