### PR TITLE
Add more options to conditionally show node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ set -g theme_newline_prompt '$ '
 **Prompt options**
 
 - `theme_display_ruby`. Use `no` to completely hide all information about Ruby version. By default Ruby version displayed if there is the difference from default settings.
-- `theme_display_node`. If set to `yes`, will display current NVM or FNM node version. If set to `rc`, will display the version if an `.nvmrc` or `.node-version` file is found. If set to `package`, will display the version if a `package.json` file is found.
+- `theme_display_node`. If set to `always`, will display current NPM, NVM or FNM node version. If set to `yes`, will display the version if an `.nvmrc`, `.node-version` or `package.json` file is found in the parent directories.
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
 - `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `yes` to show the indicator.
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ set -g theme_newline_prompt '$ '
 **Prompt options**
 
 - `theme_display_ruby`. Use `no` to completely hide all information about Ruby version. By default Ruby version displayed if there is the difference from default settings.
-- `theme_display_node`. If set to `yes`, will display current NVM or FNM node version.
+- `theme_display_node`. If set to `yes`, will display current NVM or FNM node version. If set to `rc`, will display the version if an `.nvmrc` or `.node-version` file is found. If set to `package`, will display the version if a `package.json` file is found.
 - `theme_display_vagrant`. This feature is disabled by default, use `yes` to display Vagrant status in your prompt. Please note that only the VirtualBox and VMWare providers are supported.
 - `theme_display_vi`. By default the vi mode indicator will be shown if vi or hybrid key bindings are enabled. Use `no` to hide the indicator, or `yes` to show the indicator.
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -895,17 +895,19 @@ function __bobthefish_prompt_desk -S -d 'Display current desk environment'
     set_color normal
 end
 
-function __bobthefish_prompt_find_file_up_re -S -d 'Find file(s) (as a regex), going up the parent directories'
+function __bobthefish_prompt_find_file_up -S -d 'Find file(s), going up the parent directories'
     set -l dir "$argv[1]"
-    set -l file "$argv[2]"
+    set -l files $argv[2..]
 
     if [ -z "$dir" ]
         return 1
     end
 
     while [ "$dir" ]
-        if string match -q -r "$dir/($file)\$" -- $dir/*
-            return
+        for f in $files
+            if [ -e "$dir/$f" ]
+                return
+            end
         end
 
         set dir (__bobthefish_dirname "$dir")
@@ -919,7 +921,7 @@ function __bobthefish_prompt_node -S -d 'Display current node version'
     if [ "$theme_display_node" = 'always' -o "$theme_display_nvm" = 'yes' ]
         set should_show 1
     else if [ "$theme_display_node" = 'yes' ]
-        __bobthefish_prompt_find_file_up_re "$PWD" '\.nvmrc|\.node-version|package\.json'
+        __bobthefish_prompt_find_file_up "$PWD" package.json .nvmrc .node-version
         and set should_show 1
     end
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -916,15 +916,10 @@ end
 function __bobthefish_prompt_node -S -d 'Display current node version'
     set -l should_show
 
-    if [ "$theme_display_node" = 'yes' -o "$theme_display_nvm" = 'yes' ]
+    if [ "$theme_display_node" = 'always' -o "$theme_display_nvm" = 'yes' ]
         set should_show 1
-    else if [ "$theme_display_node" = 'rc' ]
-        begin
-            __bobthefish_prompt_find_file_up_re "$PWD" '\.nvmrc|\.node-version'
-        end
-        and set should_show 1
-    else if [ "$theme_display_node" = 'package' ]
-        __bobthefish_prompt_find_file_up_re "$PWD" 'package\.json'
+    else if [ "$theme_display_node" = 'yes' ]
+        __bobthefish_prompt_find_file_up_re "$PWD" '\.nvmrc|\.node-version|package\.json'
         and set should_show 1
     end
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -895,7 +895,7 @@ function __bobthefish_prompt_desk -S -d 'Display current desk environment'
     set_color normal
 end
 
-function __bobthefish_prompt_find_file -S -d 'Find a file by going up the parent directories'
+function __bobthefish_prompt_find_file_up_re -S -d 'Find file(s) (as a regex), going up the parent directories'
     set -l dir "$argv[1]"
     set -l file "$argv[2]"
 
@@ -903,12 +903,12 @@ function __bobthefish_prompt_find_file -S -d 'Find a file by going up the parent
         return 1
     end
 
-    while [ "$dir" != '/' ]
-        if [ -f "$dir/$file" ]
+    while [ "$dir" ]
+        if string match -q -r "$dir/($file)\$" -- $dir/*
             return
         end
 
-        set dir (dirname "$dir")
+        set dir (__bobthefish_dirname "$dir")
     end
     return 1
 end
@@ -920,12 +920,11 @@ function __bobthefish_prompt_node -S -d 'Display current node version'
         set should_show 1
     else if [ "$theme_display_node" = 'rc' ]
         begin
-            __bobthefish_prompt_find_file "$PWD" .nvmrc
-            or __bobthefish_prompt_find_file "$PWD" .node-version
+            __bobthefish_prompt_find_file_up_re "$PWD" '\.nvmrc|\.node-version'
         end
         and set should_show 1
     else if [ "$theme_display_node" = 'package' ]
-        __bobthefish_prompt_find_file "$PWD" package.json
+        __bobthefish_prompt_find_file_up_re "$PWD" 'package\.json'
         and set should_show 1
     end
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -895,9 +895,42 @@ function __bobthefish_prompt_desk -S -d 'Display current desk environment'
     set_color normal
 end
 
+function __bobthefish_prompt_find_file -S -d 'Find a file by going up the parent directories'
+    set -l dir "$argv[1]"
+    set -l file "$argv[2]"
+
+    if [ -z "$dir" ]
+        return 1
+    end
+
+    while [ "$dir" != '/' ]
+        if [ -f "$dir/$file" ]
+            return
+        end
+
+        set dir (dirname "$dir")
+    end
+    return 1
+end
+
 function __bobthefish_prompt_node -S -d 'Display current node version'
-    [ "$theme_display_node" = 'yes' -o "$theme_display_nvm" = 'yes' ]
-    or return
+    set -l should_show
+
+    if [ "$theme_display_node" = 'yes' -o "$theme_display_nvm" = 'yes' ]
+        set should_show 1
+    else if [ "$theme_display_node" = 'rc' ]
+        begin
+            __bobthefish_prompt_find_file "$PWD" .nvmrc
+            or __bobthefish_prompt_find_file "$PWD" .node-version
+        end
+        and set should_show 1
+    else if [ "$theme_display_node" = 'package' ]
+        __bobthefish_prompt_find_file "$PWD" package.json
+        and set should_show 1
+    end
+
+    [ -z "$should_show" ]
+    and return
 
     set -l node_manager
     set -l node_manager_dir

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -899,7 +899,8 @@ function __bobthefish_prompt_find_file_up -S -d 'Find file(s), going up the pare
     set -l dir "$argv[1]"
     set -l files $argv[2..]
 
-    if [ -z "$dir" ]
+    if test -z "$dir"
+        or test -z "$files"
         return 1
     end
 
@@ -909,6 +910,9 @@ function __bobthefish_prompt_find_file_up -S -d 'Find file(s), going up the pare
                 return
             end
         end
+
+        [ "$dir" = '/' ]
+        and return 1
 
         set dir (__bobthefish_dirname "$dir")
     end


### PR DESCRIPTION
There are now 4 options for `$theme_display_node`:

- the default is (still) to never show it.
- `yes` to always show the version.
- `rc` to show it if we can find a `.nvmrc` or `.node-version` file in the parent directories.
- `package` to show it if we can find a `package.json` file in the parent directories.
