### PR TITLE
Dracula theme: Fix Kubernetes colors

### DIFF
--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -516,7 +516,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_vi_mode_visual           $orange $bg --bold
 
       set -x color_vagrant                  $pink $bg --bold
-      set -x color_k8s                      $green $fg --bold
+      set -x color_k8s                      $purple $bg --bold
       set -x color_aws_vault                $comment $yellow --bold
       set -x color_aws_vault_expired        $comment $red --bold
       set -x color_username                 $selection $cyan --bold


### PR DESCRIPTION
Hello,

By default, the Kubernetes colors are displayed like so:
<img width="143" alt="image" src="https://user-images.githubusercontent.com/2109178/147569571-e79295b9-7425-4d82-9e07-ab680baf9685.png">

It's hard to read, and really bright, seeking for our attention. 
The purpose of displaying Kubernetes context is just to know where our `kubectl`commands will run, so it's nice to know, but not a major information that should get all our attention in my opinion.

So I tried others colors, and either we could replace the white text with a darker color:
<img width="148" alt="image" src="https://user-images.githubusercontent.com/2109178/147569708-4e86c440-0326-45a9-a2b4-679f8e545958.png">

Or, what I suggest in this PR, use purple as it's less attention seeking:
<img width="145" alt="image" src="https://user-images.githubusercontent.com/2109178/147569731-c2b22139-66f4-4eba-a425-e2d4268c734c.png">

**Original version:**
<img width="1138" alt="Screenshot 2021-12-28 at 14 16 44" src="https://user-images.githubusercontent.com/2109178/147570183-1bdfe259-02c7-484b-9882-782fbf0e7431.png">

**Version with darker text:**
<img width="1138" alt="Screenshot 2021-12-28 at 14 16 46" src="https://user-images.githubusercontent.com/2109178/147570201-ef68fc13-d000-49ab-b163-ff783db6eaee.png">

**Suggested changes:**
<img width="1138" alt="Screenshot 2021-12-28 at 14 16 49" src="https://user-images.githubusercontent.com/2109178/147570210-7ff1bee8-7032-44c1-b9ec-ee92ba125411.png">

Tell me what you think :)