### PR TITLE
Add support to show the set Azure subscription using the az cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ set -g theme_use_abbreviated_branch_name yes
 set -g theme_display_vagrant yes
 set -g theme_display_docker_machine no
 set -g theme_display_k8s_context yes
+set -g theme_display_azure_subscription yes
+set -g theme_display_azure_subscription_truncate yes
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
 set -g theme_display_nix no
@@ -130,6 +132,8 @@ set -g theme_newline_prompt '$ '
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).
 - `theme_display_k8s_namespace`. This feature is disabled by default. Use `yes` to show the current kubernetes namespace.
 - `theme_display_aws_vault_profile`. This feature is disabled by default. Use `yes` to show the currently executing [AWS Vault](https://github.com/99designs/aws-vault) profile.
+- `theme_display_azure_subscription`. This feature is disabled by default. Use `yes` to show the currently select [Azure](https://docs.microsoft.com/en-us/cli/azure/) subscription.
+- `theme_display_azure_subscription_truncate`. Set to `yes` to truncate the azure subscription name in the promp.
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_display_sudo_user`. If set to `yes`, displays the sudo-username in a root shell. For example, when calling `sudo -s` and having this option set to `yes`, the username of the user, who called `sudo -s`, will be displayed.

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -614,6 +614,7 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
 
       set -x color_vagrant                  $blue[1] $white --bold
       set -x color_k8s                      $green[2] $white --bold
+      set -x color_azure                    008AD7 $white --bold
       set -x color_aws_vault                $blue[3] $orange[1] --bold
       set -x color_aws_vault_expired        $blue[3] $red[3] --bold
       set -x color_username                 $grey[1] $blue[3] --bold

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -30,6 +30,9 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
   # Kubernetes glyphs
   set -x k8s_glyph               \u2388 # '⎈'
 
+  # Azure glyphs
+  set -x azure_glyph             \ufd03 # ﴃ 'nf-mdi-azure'
+
   # Vagrant glyphs
   set -x vagrant_running_glyph   \u2191 # ↑ 'running'
   set -x vagrant_poweroff_glyph  \u2193 # ↓ 'poweroff'

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -31,6 +31,8 @@
 #     set -g theme_display_k8s_context yes
 #     set -g theme_display_k8s_namespace no
 #     set -g theme_display_aws_vault_profile yes
+#     set -g theme_display_azure_subscription yes
+#     set -g theme_display_azure_subscription_truncate yes
 #     set -g theme_display_hg yes
 #     set -g theme_display_virtualenv no
 #     set -g theme_display_nix no
@@ -682,6 +684,28 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     echo -ns $segment ' '
 end
 
+function __bobthefish_prompt_azure_subscription -S -d 'Show current Azure subscription'
+    [ "$theme_display_azure_subscription" = yes ]
+    or return
+
+    set -l azure_profile ~/.azure/azureProfile.json
+
+    if type -q jq && test -e $azure_profile
+        set -l subscription_name (jq -r '.subscriptions[] | select(.isDefault == true).name' $azure_profile)
+
+        if test -z $subscription_name
+            return
+        end
+
+        [ "$theme_display_azure_subscription_truncate" = yes ]
+        and set subscription_name (string replace -r '^(.{17}).{3,}(.{5})$' "\$1…\$2" $subscription_name)
+
+        set -l segment $azure_glyph ' ' $subscription_name
+        __bobthefish_start_segment $color_azure
+        echo -ns $segment ' '
+    end
+end
+
 
 # ==============================
 # User / hostname info segments
@@ -1167,6 +1191,7 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
 
     # Cloud Tools
     __bobthefish_prompt_aws_vault_profile
+    __bobthefish_prompt_azure_subscription
 
     # Virtual environments
     __bobthefish_prompt_nix


### PR DESCRIPTION
Parses the `~/.azure/azureProfile.json` if it exists using `jq` (required and tested if present), and selects the name of the default subscription.