### PR TITLE
Support using Windows git under WSL

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -157,6 +157,8 @@ function __bobthefish_git_project_dir -S -a real_pwd -d 'Print the current git p
 
         [ -z "$git_toplevel" ]
         and return
+        
+        command -q wslpath; and set -l git_toplevel (command wslpath $git_toplevel)
 
         # If there are no symlinks, just use git toplevel
         switch $real_pwd/


### PR DESCRIPTION
Linux Git is unusably slow when accessing repos in the Windows filesystem when using WSL; using Windows Git fixes this issue but it breaks the prompt since Windows Git returns Windows paths.

This converts the path to the equivalent POSIX path which restores the prompt under this setup; it should just return the original path when passed a POSIX path, and do nothing on non-WSL systems.