### PR TITLE
Hide k8s context or namespace when they are 'default'

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -641,8 +641,10 @@ function __bobthefish_prompt_k8s_context -S -d 'Show current Kubernetes context'
     and [ -z $namespace -o "$namespace" = 'default' ]
     and return
 
-    set -l segment $k8s_glyph ' ' $context
-    [ -n "$namespace" ]
+    set -l segment $k8s_glyph ' '
+    [ "$context" != 'default' ]
+    and set segment $segment $context
+    [ "$namespace" != 'default' ]
     and set segment $segment ':' $namespace
 
     __bobthefish_start_segment $color_k8s


### PR DESCRIPTION
Kept the `:` prefix for the namespace to denote that it is in fact a namespace and not a context when context is default and thus down hidden.