### PR TITLE
Fix error when k8s context defined but namespace isn't

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -637,8 +637,8 @@ function __bobthefish_prompt_k8s_context -S -d 'Show current Kubernetes context'
     [ "$theme_display_k8s_namespace" = 'yes' ]
     and set -l namespace (__bobthefish_k8s_namespace)
 
-    [ -z $context -o "$context" = 'default' ]
-    and [ -z $namespace -o "$namespace" = 'default' ]
+    [ -z "$context" -o "$context" = 'default' ]
+    and [ -z "$namespace" -o "$namespace" = 'default' ]
     and return
 
     set -l segment $k8s_glyph ' '


### PR DESCRIPTION
Fixed simple mistake of not double qouting namespace so when empty -z consumed -o as its input.