### PR TITLE
Fix pwd calculation for git worktrees

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -185,7 +185,7 @@ function __bobthefish_git_project_dir -S -a real_pwd -d 'Print the current git p
     or return
 
     pushd $git_dir
-    set git_dir $real_pwd
+    set git_dir (__bobthefish_pwd)
     popd
 
     switch $real_pwd/


### PR DESCRIPTION
A refactor changed this block from a `set git_dir $PWD` to `set git_dir $real_pwd`, but as `real_pwd` is a "static" variable and not dynamically computed, this breaks within the `pushd` / `popd` flow.

Instead of using `$real_pwd`, we need to compute the *current* directory by calling `__bobthefish_pwd` again.

Fixes #249.


---

btw, I'm not 100% certain about this worktree-support anyways. For me, it doesn't "work", or rather, I'm using worktrees but the normal git-prompt works fine.

My use-case is different from what was described in the [original issue for worktrees](https://github.com/oh-my-fish/theme-bobthefish/issues/29), and have the following directory structure:
```
$ git worktree list
/tmp/repo/main                     562496718 [main]
/tmp/repo/branch123                2fc53b215 [branch123]
/tmp/repo/another-branch           5615bf3bb [another-branch]
```

but the `.git` repo is in `tmp/repo/main/.git`. 

So my current git-prompts look like this:
```
/p/t/r/branch123 || branch123 || 
```
Meaning the branch is shown twice, once in the git-info and once in the path, while I have no idea in what project I'm in :) 

In my case, I'd rather have the left part of the prompt show me the project, with the "branch directory" trimmed away, as that's show in the git-info already. 

I don't think there's a generic solution to how people use worktrees, at least I can't see a common theme between #29 and my use-case, so I might have a look at making this functionality customisable _somehow_, although I'm not quite sure yet how to do that :) 

Thanks a lot for this great theme & prompt!