### PR TITLE
Make displaying python version glyph in virtualenv segment configurable

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -873,11 +873,7 @@ function __bobthefish_prompt_virtualfish -S -d "Display current Python virtual e
 
     if [ "$version_glyph" -o "$theme_display_virtualenv_python_version" = 'no' ]
         __bobthefish_start_segment $color_virtualfish
-        echo -ns $virtualenv_glyph
-        if [ "$theme_display_virtualenv_python_version" != 'no' ]
-            echo -ns $version_glyph
-        end
-        echo -ns ' '
+        echo -ns $virtualenv_glyph $version_glyph ' '
     end
 
     if [ "$VIRTUAL_ENV" ]

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -871,7 +871,7 @@ function __bobthefish_prompt_virtualfish -S -d "Display current Python virtual e
 
     set -l version_glyph (__bobthefish_virtualenv_python_version)
 
-    if [ "$version_glyph" ]
+    if [ "$version_glyph" -o "$theme_display_virtualenv_python_version" = 'no' ]
         __bobthefish_start_segment $color_virtualfish
         echo -ns $virtualenv_glyph
         if [ "$theme_display_virtualenv_python_version" != 'no' ]

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -873,7 +873,11 @@ function __bobthefish_prompt_virtualfish -S -d "Display current Python virtual e
 
     if [ "$version_glyph" ]
         __bobthefish_start_segment $color_virtualfish
-        echo -ns $virtualenv_glyph $version_glyph ' '
+        echo -ns $virtualenv_glyph
+        if [ "$theme_display_virtualenv_python_version" != 'no' ]
+            echo -ns $version_glyph
+        end
+        echo -ns ' '
     end
 
     if [ "$VIRTUAL_ENV" ]

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -33,6 +33,7 @@
 #     set -g theme_display_aws_vault_profile yes
 #     set -g theme_display_hg yes
 #     set -g theme_display_virtualenv no
+#     set -g theme_display_virtualenv_python_version no
 #     set -g theme_display_nix no
 #     set -g theme_display_ruby no
 #     set -g theme_display_user ssh
@@ -849,6 +850,9 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
 end
 
 function __bobthefish_virtualenv_python_version -S -d 'Get current Python version'
+    [ "$theme_display_virtualenv_python_version" = 'no' ]
+    and return
+
     switch (python --version 2>&1 | tr '\n' ' ')
         case 'Python 2*PyPy*'
             echo $pypy_glyph


### PR DESCRIPTION
Motivation: On my machine, `python --version` is taking 664ms to execute; this is then getting tacked onto every single shell command due to `__bobthefish_prompt_virtualfish` calling `python --version` to decide which version glyph to display. I'm not sure if `python --version` is simply not supposed to take that long, but I find it useful to have the current virtualenv displayed regardless, so making this configurable seems like the best route.

`$theme_display_virtualenv_python_version` is checked twice because I figured it was best to preserve the current behavior of "if the python version doesn't match any case, don't display the virtualenv color and glyph at all".