### PR TITLE
Add AWS_VAULT to prompt - option

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1212,3 +1212,6 @@ function fish_prompt -d 'bobthefish, a fish theme optimized for awesome'
 
     __bobthefish_finish_segments
 end
+if set -q VIRTUAL_ENV
+    echo -n -s (set_color -b blue white) "(" (basename "$VIRTUAL_ENV") ")" (set_color normal) " "
+end


### PR DESCRIPTION
In addition to the AWS_VAULT profile, it's also handy to see the currently active AWS Profile. It's not mutually exclusive.
But not everyone uses `aws-vault` but e.g. granted.dev and `assume`. Which only set's the profile and does not use `aws-vault`. A dedicated setting can ensure that these two don't clash and are disabled by default