### PR TITLE
Use `status current-command` for title

### DIFF
--- a/functions/fish_title.fish
+++ b/functions/fish_title.fish
@@ -18,7 +18,7 @@ function fish_title
     __bobthefish_title_user
 
     if [ "$theme_title_display_process" = 'yes' ]
-        echo $_
+        status current-command
 
         [ "$theme_title_display_path" != 'no' ]
         and echo ' '


### PR DESCRIPTION
Hello! Thank you very much for this awesome theme! I love it.

I noticed a little issue though:

1. `$_` is marked as deprecated https://fishshell.com/docs/current/language.html#envvar-_
2. `$_` contains wrong process name in cases like this one:

  ```fish
  sleep 1000 # `sleep` is the process, now press Ctrl-Z to suspend
  fg # unsuspend it, now `fg` is shown as the process
  ```

  `status current-command` will show `sleep` instead, which makes more
  sense.