### PR TITLE
Add Catppuccin color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ one of the following options to change the prompt colors.
 - `gruvbox`. An adaptation of gruvbox.
 - `dracula`. An adaptation of dracula.
 - `nord`. An adaptation of nord.
+- `catpuccin-latte`, `catpuccin-frappe`, `catpuccin-macchiato`, `catpuccin-mocha`. Adaptations of the Cattpuccin themes.
 
 Some of these may not look right if your terminal does not support 24 bit color,
 in which case you can try one of the `terminal` schemes (below). However, if

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -639,6 +639,66 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_desk                     $peach $mantle --bold
       set -x color_nix                      $sky $mantle --bold
 
+    case 'catppuccin-frappe'
+      set -l rosewater f2d5cf
+      set -l flamingo  eebebe
+      set -l pink      f4b8e4
+      set -l mauve     ca9ee6
+      set -l red       e78284
+      set -l maroon    ea999c
+      set -l peach     ef9f76
+      set -l yellow    e5c890
+      set -l green     a6d189
+      set -l teal      81c8be
+      set -l sky       99d1db
+      set -l sapphire  85c1dc
+      set -l blue      8caaee
+      set -l lavender  babbf1
+      set -l text      c6d0f5
+      set -l subtext1  b5bfe2
+      set -l subtext0  a5adce
+      set -l overlay2  949cbb
+      set -l overlay1  838ba7
+      set -l overlay0  737994
+      set -l surface2  626880
+      set -l surface1  51576d
+      set -l surface0  414559
+      set -l base      303446
+      set -l mantle    292c3c
+      set -l crust     232634
+
+      set -x color_initial_segment_exit     $surface2 $red  --bold
+      set -x color_initial_segment_private  $surface2 $flamingo
+      set -x color_initial_segment_su       $surface2 $green --bold
+      set -x color_initial_segment_jobs     $surface2 $peach --bold
+
+      set -x color_path                     $surface0 $text
+      set -x color_path_basename            $surface0 $text --bold
+      set -x color_path_nowrite             $surface0 $mauve
+      set -x color_path_nowrite_basename    $surface0 $mauve --bold
+
+      set -x color_repo                     $green $mantle
+      set -x color_repo_work_tree           $surface2 $mantle --bold
+      set -x color_repo_dirty               $red $mantle
+      set -x color_repo_staged              $yellow $mantle
+
+      set -x color_vi_mode_default          $sky $mantle --bold
+      set -x color_vi_mode_insert           $green $mantle --bold
+      set -x color_vi_mode_visual           $mauve $mantle --bold
+
+      set -x color_vagrant                  $surface2 $text --bold
+      set -x color_k8s                      $surface2 $text --bold
+      set -x color_aws_vault                $yellow $mantle --bold
+      set -x color_aws_vault_expired        $red $mantle --bold
+      set -x color_username                 $surface2 $yellow --bold
+      set -x color_hostname                 $surface2 $yellow
+      set -x color_rvm                      $red $mantle --bold
+      set -x color_node                     $green $mantle --bold
+      set -x color_virtualfish              $peach $mantle --bold
+      set -x color_virtualgo                $sky $mantle --bold
+      set -x color_desk                     $peach $mantle --bold
+      set -x color_nix                      $sky $mantle --bold
+
     case '*' # default dark theme
       #               light  medium dark
       #               ------ ------ ------

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -759,6 +759,66 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_desk                     $peach $mantle --bold
       set -x color_nix                      $sky $mantle --bold
 
+    case 'catppuccin-mocha'
+      set -l rosewater f5e0dc
+      set -l flamingo  f2cdcd
+      set -l pink      f5c2e7
+      set -l mauve     cba6f7
+      set -l red       f38ba8
+      set -l maroon    eba0ac
+      set -l peach     fab387
+      set -l yellow    f9e2af
+      set -l green     a6e3a1
+      set -l teal      94e2d5
+      set -l sky       89dceb
+      set -l sapphire  74c7ec
+      set -l blue      89b4fa
+      set -l lavender  b4befe
+      set -l text      cdd6f4
+      set -l subtext1  bac2de
+      set -l subtext0  a6adc8
+      set -l overlay2  9399b2
+      set -l overlay1  7f849c
+      set -l overlay0  6c7086
+      set -l surface2  585b70
+      set -l surface1  45475a
+      set -l surface0  313244
+      set -l base      1e1e2e
+      set -l mantle    181825
+      set -l crust     11111b
+
+      set -x color_initial_segment_exit     $surface2 $red  --bold
+      set -x color_initial_segment_private  $surface2 $flamingo
+      set -x color_initial_segment_su       $surface2 $green --bold
+      set -x color_initial_segment_jobs     $surface2 $peach --bold
+
+      set -x color_path                     $surface0 $text
+      set -x color_path_basename            $surface0 $text --bold
+      set -x color_path_nowrite             $surface0 $mauve
+      set -x color_path_nowrite_basename    $surface0 $mauve --bold
+
+      set -x color_repo                     $green $mantle
+      set -x color_repo_work_tree           $surface2 $mantle --bold
+      set -x color_repo_dirty               $red $mantle
+      set -x color_repo_staged              $yellow $mantle
+
+      set -x color_vi_mode_default          $sky $mantle --bold
+      set -x color_vi_mode_insert           $green $mantle --bold
+      set -x color_vi_mode_visual           $mauve $mantle --bold
+
+      set -x color_vagrant                  $surface2 $text --bold
+      set -x color_k8s                      $surface2 $text --bold
+      set -x color_aws_vault                $yellow $mantle --bold
+      set -x color_aws_vault_expired        $red $mantle --bold
+      set -x color_username                 $surface2 $yellow --bold
+      set -x color_hostname                 $surface2 $yellow
+      set -x color_rvm                      $red $mantle --bold
+      set -x color_node                     $green $mantle --bold
+      set -x color_virtualfish              $peach $mantle --bold
+      set -x color_virtualgo                $sky $mantle --bold
+      set -x color_desk                     $peach $mantle --bold
+      set -x color_nix                      $sky $mantle --bold
+
     case '*' # default dark theme
       #               light  medium dark
       #               ------ ------ ------

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -579,6 +579,66 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_virtualgo                $base09 $colorfg --bold
       set -x color_desk                     $base09 $colorfg --bold
 
+    case 'catppuccin-latte'
+      set -l rosewater dc8a78
+      set -l flamingo  dd7878
+      set -l pink      ea76cb
+      set -l mauve     8839ef
+      set -l red       d20f39
+      set -l maroon    e64553
+      set -l peach     fe640b
+      set -l yellow    df8e1d
+      set -l green     40a02b
+      set -l teal      179299
+      set -l sky       04a5e5
+      set -l sapphire  209fb5
+      set -l blue      1e66f5
+      set -l lavender  7287fd
+      set -l text      4c4f69
+      set -l subtext1  5c5f77
+      set -l subtext0  6c6f85
+      set -l overlay2  7c7f93
+      set -l overlay1  8c8fa1
+      set -l overlay0  9ca0b0
+      set -l surface2  acb0be
+      set -l surface1  bcc0cc
+      set -l surface0  ccd0da
+      set -l base      eff1f5
+      set -l mantle    e6e9ef
+      set -l crust     dce0e8
+
+      set -x color_initial_segment_exit     $surface2 $red  --bold
+      set -x color_initial_segment_private  $surface2 $flamingo
+      set -x color_initial_segment_su       $surface2 $green --bold
+      set -x color_initial_segment_jobs     $surface2 $peach --bold
+
+      set -x color_path                     $surface0 $text
+      set -x color_path_basename            $surface0 $text --bold
+      set -x color_path_nowrite             $surface0 $mauve
+      set -x color_path_nowrite_basename    $surface0 $mauve --bold
+
+      set -x color_repo                     $green $mantle
+      set -x color_repo_work_tree           $surface2 $mantle --bold
+      set -x color_repo_dirty               $red $mantle
+      set -x color_repo_staged              $yellow $mantle
+
+      set -x color_vi_mode_default          $sky $mantle --bold
+      set -x color_vi_mode_insert           $green $mantle --bold
+      set -x color_vi_mode_visual           $mauve $mantle --bold
+
+      set -x color_vagrant                  $surface2 $text --bold
+      set -x color_k8s                      $surface2 $text --bold
+      set -x color_aws_vault                $yellow $mantle --bold
+      set -x color_aws_vault_expired        $red $mantle --bold
+      set -x color_username                 $surface2 $yellow --bold
+      set -x color_hostname                 $surface2 $yellow
+      set -x color_rvm                      $red $mantle --bold
+      set -x color_node                     $green $mantle --bold
+      set -x color_virtualfish              $peach $mantle --bold
+      set -x color_virtualgo                $sky $mantle --bold
+      set -x color_desk                     $peach $mantle --bold
+      set -x color_nix                      $sky $mantle --bold
+
     case '*' # default dark theme
       #               light  medium dark
       #               ------ ------ ------

--- a/functions/__bobthefish_colors.fish
+++ b/functions/__bobthefish_colors.fish
@@ -699,6 +699,66 @@ function __bobthefish_colors -S -a color_scheme -d 'Define colors used by bobthe
       set -x color_desk                     $peach $mantle --bold
       set -x color_nix                      $sky $mantle --bold
 
+    case 'catppuccin-macchiato'
+      set -l rosewater f4dbd6
+      set -l flamingo  f0c6c6
+      set -l pink      f5bde6
+      set -l mauve     c6a0f6
+      set -l red       ed8796
+      set -l maroon    ee99a0
+      set -l peach     f5a97f
+      set -l yellow    eed49f
+      set -l green     a6da95
+      set -l teal      8bd5ca
+      set -l sky       91d7e3
+      set -l sapphire  7dc4e4
+      set -l blue      8aadf4
+      set -l lavender  b7bdf8
+      set -l text      cad3f5
+      set -l subtext1  b8c0e0
+      set -l subtext0  a5adcb
+      set -l overlay2  939ab7
+      set -l overlay1  8087a2
+      set -l overlay0  6e738d
+      set -l surface2  5b6078
+      set -l surface1  494d64
+      set -l surface0  363a4f
+      set -l base      24273a
+      set -l mantle    1e2030
+      set -l crust     181926
+
+      set -x color_initial_segment_exit     $surface2 $red  --bold
+      set -x color_initial_segment_private  $surface2 $flamingo
+      set -x color_initial_segment_su       $surface2 $green --bold
+      set -x color_initial_segment_jobs     $surface2 $peach --bold
+
+      set -x color_path                     $surface0 $text
+      set -x color_path_basename            $surface0 $text --bold
+      set -x color_path_nowrite             $surface0 $mauve
+      set -x color_path_nowrite_basename    $surface0 $mauve --bold
+
+      set -x color_repo                     $green $mantle
+      set -x color_repo_work_tree           $surface2 $mantle --bold
+      set -x color_repo_dirty               $red $mantle
+      set -x color_repo_staged              $yellow $mantle
+
+      set -x color_vi_mode_default          $sky $mantle --bold
+      set -x color_vi_mode_insert           $green $mantle --bold
+      set -x color_vi_mode_visual           $mauve $mantle --bold
+
+      set -x color_vagrant                  $surface2 $text --bold
+      set -x color_k8s                      $surface2 $text --bold
+      set -x color_aws_vault                $yellow $mantle --bold
+      set -x color_aws_vault_expired        $red $mantle --bold
+      set -x color_username                 $surface2 $yellow --bold
+      set -x color_hostname                 $surface2 $yellow
+      set -x color_rvm                      $red $mantle --bold
+      set -x color_node                     $green $mantle --bold
+      set -x color_virtualfish              $peach $mantle --bold
+      set -x color_virtualgo                $sky $mantle --bold
+      set -x color_desk                     $peach $mantle --bold
+      set -x color_nix                      $sky $mantle --bold
+
     case '*' # default dark theme
       #               light  medium dark
       #               ------ ------ ------

--- a/functions/bobthefish_display_colors.fish
+++ b/functions/bobthefish_display_colors.fish
@@ -5,6 +5,8 @@ function bobthefish_display_colors -a color_scheme -d 'Print example prompt colo
     base16 base16-light \
     gruvbox zenburn \
     dracula nord \
+    catppuccin-latte catppuccin-frappe \
+    catppuccin-macchiato catppuccin-mocha \
     terminal terminal-dark-white \
     terminal-light terminal-light-black \
     terminal2 terminal2-dark-white \


### PR DESCRIPTION
This PR includes all four variants of the [Catppuccin](https://github.com/catppuccin/catppuccin) Theme.  
Namely Latte, Frappe, Macchiato, and Mocha.