### PR TITLE
Add option to hide python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This theme is based loosely on [agnoster][btf-agnoster].
 
 ### Configuration
 
-You can override some of the following default options in your `config.fish`:
+You can override some of the following default options in your `config.fish` or `.conf/omf/init.fish`:
 
 ```fish
 set -g theme_display_git no
@@ -83,6 +83,7 @@ set -g theme_display_docker_machine no
 set -g theme_display_k8s_context yes
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
+set -g theme_hide_python_version yes
 set -g theme_display_nix no
 set -g theme_display_ruby no
 set -g theme_display_node yes

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ set -g theme_display_k8s_context yes
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
 set -g theme_display_virtualenv verbose
-set -g theme_hide_python_version yes
 set -g theme_display_nix no
 set -g theme_display_ruby no
 set -g theme_display_node yes

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ set -g theme_display_docker_machine no
 set -g theme_display_k8s_context yes
 set -g theme_display_hg yes
 set -g theme_display_virtualenv no
+set -g theme_display_virtualenv verbose
 set -g theme_hide_python_version yes
 set -g theme_display_nix no
 set -g theme_display_ruby no

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -33,6 +33,7 @@
 #     set -g theme_display_aws_vault_profile yes
 #     set -g theme_display_hg yes
 #     set -g theme_display_virtualenv no
+#     set -g theme_display_virtualenv verbose
 #     set -g theme_display_nix no
 #     set -g theme_display_ruby no
 #     set -g theme_display_user ssh
@@ -50,8 +51,6 @@
 #     set -g fish_prompt_pwd_dir_length 0
 #     set -g theme_project_dir_length 1
 #     set -g theme_newline_cursor yes
-#     set -g theme_hide_python_version yes
-
 
 # ==============================
 # Helper methods
@@ -867,14 +866,22 @@ function __bobthefish_prompt_virtualfish -S -d "Display current Python virtual e
     and return
 
     set -l version_glyph (__bobthefish_virtualenv_python_version)
+    set -l prompt_style 'default'
 
     if [ "$version_glyph" ]
         __bobthefish_start_segment $color_virtualfish
-        if [ "$theme_hide_python_version" = yes ]
-            echo -ns $virtualenv_glyph
-        else
-            echo -ns $virtualenv_glyph $version_glyph ' '
+        if string match -q "Python 2*" (python --version 2>&1 | string trim)
+            set prompt_style 'verbose'
+        else if [ "$theme_display_virtualenv" = 'verbose' ]
+            set prompt_style 'verbose'
         end
+
+        if [ "$prompt_style" = 'verbose' ]
+            echo -ns $virtualenv_glyph $version_glyph ' '
+        else
+            echo -ns $virtualenv_glyph
+        end
+
     end
 
     if [ "$VIRTUAL_ENV" ]

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -50,6 +50,7 @@
 #     set -g fish_prompt_pwd_dir_length 0
 #     set -g theme_project_dir_length 1
 #     set -g theme_newline_cursor yes
+#     set -g theme_hide_python_version yes
 
 
 # ==============================
@@ -869,7 +870,11 @@ function __bobthefish_prompt_virtualfish -S -d "Display current Python virtual e
 
     if [ "$version_glyph" ]
         __bobthefish_start_segment $color_virtualfish
-        echo -ns $virtualenv_glyph $version_glyph ' '
+        if [ "$theme_hide_python_version" = yes ]
+            echo -ns $virtualenv_glyph
+        else
+            echo -ns $virtualenv_glyph $version_glyph ' '
+        end
     end
 
     if [ "$VIRTUAL_ENV" ]


### PR DESCRIPTION
This adds a simple option (via `set -g theme_hide_python_version yes`) to hide the Python version using virtualenv.

Personally, I believe most people only develop in Python 3 nowadays, so having the extra space just to show the version seems unnecessary.

PS: thanks for this awesome theme! 😀