### PR TITLE
Fix golang version prompt when go directive in go.mod has patch version

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -851,7 +851,7 @@ function __bobthefish_prompt_golang -S -a real_pwd -d 'Display current Go inform
     set -l actual_go_version "0"
     set -l high_enough_version "0"
     if type -fq go
-        set actual_go_version (go version | string match -r 'go version go(\\d+\\.\\d+)' -g)
+        set actual_go_version (go version | string match -r 'go version go(\\d+\\.\\d+(?:\\.\\d+)?)' -g)
         if printf "%s\n%s"  "$gomod_version" "$actual_go_version" | sort --check=silent --version-sort
             set high_enough_version "1"
         end


### PR DESCRIPTION
When the go directive in `go.mod` includes the patch version, i.e. `1.22.1` for instance, the prompt function treats it as `1.22` and fails to verify that the installed go version is high enough.