### PR TITLE
Add Fossil VCS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ This theme is based loosely on [agnoster][btf-agnoster].
      * Unpushed commits (**`+`**)
      * Unpulled _and_ unpushed commits (**`±`**)
      * _Note that not all of these have been implemented for hg yet :)_
+ * Fossil status:
+     * Dirty working directory (**`*`**)
+     * Untracked files (**`…`**)
+     * Conflicts (**`!`**)
  * Abbreviated project-relative path
 
 
@@ -243,6 +247,10 @@ If you do any Git worktree shenanigans, setting this to `yes` will fix incorrect
 #### `set -g theme_display_hg yes`
 
 This feature is disabled by default. Use `yes` to enable Mercurial support in Bobthefish. If you don't use Mercurial, leave it disabled because it's ... not fast.
+
+#### `set -g theme_display_fossil yes`
+
+This feature is also disabled by default. It should be faster than Mercurial, but if you aren't using Fossil it's safe to leave disabled.
 
 #### `set -g theme_vcs_ignore_paths /some/path /some/other/path{foo,bar}`
 

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -50,7 +50,7 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
   set -x git_plus_minus_glyph '±'
 
   # Fossil glyph (it reuses most of the git glyphs)
-  set -x fossil_glyph '🦴'
+  set -x fossil_glyph \U1F9B4 # Unicode bone emoji
 
   # Disable Powerline fonts (unless we're using nerd fonts instead)
   if [ "$theme_powerline_fonts" = "no" -a "$theme_nerd_fonts" != "yes" ]
@@ -86,7 +86,7 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
     set git_stashed_glyph    \uF0C6 '' # nf-fa-paperclip
     set git_untracked_glyph  \uF128 '' # nf-fa-question
     # set git_untracked_glyph  \uF141 '' # nf-fa-ellipsis_h
-    set fossil_glyph '󰂹'
+    set fossil_glyph \UF00B9 # nf-md-bone
 
     set git_ahead_glyph      \uF47B # nf-oct-chevron_up
     set git_behind_glyph     \uF47C # nf-oct-chevron_down
@@ -99,5 +99,6 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
   # Avoid ambiguous glyphs
   if [ "$theme_avoid_ambiguous_glyphs" = "yes" ]
     set git_untracked_glyph '...'
+    set fossil_glyph '' # blank, for lack of a good fallback
   end
 end

--- a/functions/__bobthefish_glyphs.fish
+++ b/functions/__bobthefish_glyphs.fish
@@ -49,6 +49,9 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
   set -x git_minus_glyph      '-'
   set -x git_plus_minus_glyph '±'
 
+  # Fossil glyph (it reuses most of the git glyphs)
+  set -x fossil_glyph '🦴'
+
   # Disable Powerline fonts (unless we're using nerd fonts instead)
   if [ "$theme_powerline_fonts" = "no" -a "$theme_nerd_fonts" != "yes" ]
     set private_glyph           \u29B8 ' '
@@ -83,6 +86,7 @@ function __bobthefish_glyphs -S -d 'Define glyphs used by bobthefish'
     set git_stashed_glyph    \uF0C6 '' # nf-fa-paperclip
     set git_untracked_glyph  \uF128 '' # nf-fa-question
     # set git_untracked_glyph  \uF141 '' # nf-fa-ellipsis_h
+    set fossil_glyph '󰂹'
 
     set git_ahead_glyph      \uF47B # nf-oct-chevron_up
     set git_behind_glyph     \uF47C # nf-oct-chevron_down

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -197,14 +197,15 @@ end
 
 function __bobthefish_fossil_project_dir -S -a real_pwd -d 'Print the current fossil project base directory'
     [ "$theme_display_fossil" = 'yes' ]
-    and command fossil status >/dev/null 2>/dev/null
+    and command fossil json status >/dev/null 2>/dev/null
     or return
 
     set -q theme_vcs_ignore_paths
     and [ (__bobthefish_ignore_vcs_dir $real_pwd) ]
     and return
 
-    command fossil info 2>/dev/null | sed '3q;d' | string split ' ' -f2 -n | string trim --right --chars=/
+    set -f dir (command fossil json status 2>/dev/null | grep localRoot | string split ':' -f2 | string trim --chars='"/,')
+    echo "/$dir"
 end
 
 function __bobthefish_hg_project_dir -S -a real_pwd -d 'Print the current hg project base directory'

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -197,6 +197,7 @@ end
 
 function __bobthefish_fossil_project_dir -S -a real_pwd -d 'Print the current fossil project base directory'
     [ "$theme_display_fossil" = 'yes' ]
+    and command fossil status >/dev/null 2>/dev/null
     or return
 
     set -q theme_vcs_ignore_paths

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -197,14 +197,13 @@ end
 
 function __bobthefish_fossil_project_dir -S -a real_pwd -d 'Print the current fossil project base directory'
     [ "$theme_display_fossil" = 'yes' ]
-    and command fossil json status >/dev/null 2>/dev/null
+    and set -f dir (command fossil json status 2>/dev/null | grep localRoot | string split ':' -f2 | string trim --chars='"/,')
     or return
 
     set -q theme_vcs_ignore_paths
     and [ (__bobthefish_ignore_vcs_dir $real_pwd) ]
     and return
 
-    set -f dir (command fossil json status 2>/dev/null | grep localRoot | string split ':' -f2 | string trim --chars='"/,')
     echo "/$dir"
 end
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1046,11 +1046,11 @@ function __bobthefish_prompt_fossil -S -a fossil_root_dir -a real_pwd -d 'Displa
         switch $line
             case ADDED UPDATED EDITED DELETED RENAMED
                 # These can really just all be dirty, then
-                set dirty $git_dirty_glyph
+                set -f dirty $git_dirty_glyph
             case EXTRA
-                set new $git_untracked_glyph
+                set -f new $git_untracked_glyph
             case CONFLICT
-                set conflict '!'
+                set -f conflict '!'
         end
     end
 


### PR DESCRIPTION
Started using Fossil for a project, and was annoyed that I didn't have status in my prompt. This commit adds it in!

I will admit I'm not overly familiar with Fossil, so this may be less than ideal (and might be missing important statuses), but in my testing it works pretty well. I added a new option to enable Fossil support (disabled by default, because most people won't need it; Fossil is pretty quick, so it shouldn't have the same issues as Mercurial), updated the README, and tried to stick to the same coding style as the existing code.

My one complaint about my own work is the default (non-NF) Fossil glyph, which is just the bone emoji. The NF bone emoji is alright (though I'd prefer something *more* evocative of "fossil") but I couldn't think of a better symbol outside NF.