### PR TITLE
Fix vi replace mode prompt

### DIFF
--- a/functions/fish_mode_prompt.fish
+++ b/functions/fish_mode_prompt.fish
@@ -30,7 +30,7 @@ function fish_mode_prompt -d 'bobthefish-optimized fish mode indicator'
         case insert
             set_color -b $color_vi_mode_insert
             echo -n ' I '
-        case replace_one replace-one
+        case replace replace_one replace-one
             set_color -b $color_vi_mode_insert
             echo -n ' R '
         case visual


### PR DESCRIPTION
### Reproduction

1. Execute `fish_vi_key_bindings` to enter [vi-mode](https://fishshell.com/docs/current/interactive.html#vi-mode)
2. Press <kbd>Esc</kbd>, then <kbd>Shift</kbd> + <kbd>R</kbd>
3. Mode prompt disappear unexpectedly
