### PR TITLE
Update README with better custom color scheme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,12 +354,43 @@ and bright white.
 - `terminal2-light` (or `terminal2-light-white`)
 - `terminal2-light-black`
 
-Finally, you can specify your very own color scheme by setting
-`theme_color_scheme` to `user`. In that case, you also need to define some
-variables to set the colors of the prompt. See the "Colors" section of
-`fish_prompt.fish` for details.
+### Custom Color Schemes
 
+To override the colors provided by a theme, set up a `bobthefish_colors` function in your configuration (`config.fish` or otherwise):
+```fish
+function bobthefish_colors -S -d 'Define a custom bobthefish color scheme'
 
+  # optionally include a base color scheme...
+  ___bobthefish_colors default
+
+  # then override everything you want! note that these must be defined with `set -x`
+  set -x color_initial_segment_exit     ffffff ce000f --bold
+  set -x color_initial_segment_private  ffffff 255e87
+  set -x color_initial_segment_su       ffffff 189303 --bold
+  set -x color_initial_segment_jobs     ffffff 255e87 --bold
+  set -x color_path                     333333 999999
+  set -x color_path_basename            333333 ffffff --bold
+  set -x color_path_nowrite             660000 cc9999
+  set -x color_path_nowrite_basename    660000 cc9999 --bold
+  set -x color_repo                     addc10 0c4801
+  set -x color_repo_work_tree           333333 ffffff --bold
+  set -x color_repo_dirty               ce000f ffffff
+  set -x color_repo_staged              f6b117 3a2a03
+  set -x color_vi_mode_default          999999 333333 --bold
+  set -x color_vi_mode_insert           189303 333333 --bold
+  set -x color_vi_mode_visual           f6b117 3a2a03 --bold
+  set -x color_vagrant                  48b4fb ffffff --bold
+  set -x color_aws_vault
+  set -x color_aws_vault_expired
+  set -x color_username                 cccccc 255e87 --bold
+  set -x color_hostname                 cccccc 255e87
+  set -x color_rvm                      af0000 cccccc --bold
+  set -x color_virtualfish              005faf cccccc --bold
+  set -x color_virtualgo                005faf cccccc --bold
+  set -x color_desk                     005faf cccccc --bold
+  set -x color_nix                      005faf cccccc --bold
+end
+```
 
 ## Overrides
 


### PR DESCRIPTION
Provide an up to date description of how to override colors for a theme. Ripped the code verbatim from the error you get when trying to use `set -g theme_color_scheme user`, which is in turn from functions/__bobthefish_colors.fish