### PR TITLE
Enhance support for asdf version management in README and prompt functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ This theme is based loosely on [agnoster][btf-agnoster].
      * Background jobs (**`%`**)
  * Current vi mode
  * `User@Host` (unless you're the default user)
- * Current RVM, rbenv or chruby (Ruby) version
- * Current virtualenv (Python) version
+ * Current RVM, rbenv, chruby or asdf (Ruby) version
+ * Current virtualenv (Python) version, or asdf-managed Python
      * _If you use virtualenv, you will probably need to disable the default virtualenv prompt, since it doesn't play nice with fish: `set -x VIRTUAL_ENV_DISABLE_PROMPT 1`_
- * Current NVM/FNM version (Nodejs) (inactive by default; see configurations in the next paragraph)
+ * Current NVM, FNM or asdf (Node.js) version (inactive by default; see configurations in the next paragraph)
  * Abbreviated parent directory
  * Current directory, or Git or Mercurial project name
  * Current project's repo branch (<img width="16" alt="branch-glyph" src="https://cloud.githubusercontent.com/assets/53660/8768360/53ee9b58-2e32-11e5-9977-cee0063936fa.png"> master) or detached head (`➦` d0dfd9b)
@@ -174,7 +174,9 @@ Use `no` to disable Ruby version information. By default, the Ruby version is di
 
 #### `set -g theme_display_virtualenv no`
 
-Use `no` to disable Python version information. By default, the Python version is shown when it's interesting, along with the Virtualenv or Conda environmenmt.
+Use `no` to disable Python version information. By default, the Python version is shown when it's interesting, along with the Virtualenv, Conda or asdf-managed Python environment.
+
+**asdf support:** The theme shows versions managed by [asdf](https://asdf-vm.com/) for Ruby, Node.js and Python. For each tool, the version is only shown when it comes from a local `.tool-versions` file (i.e. not the global `~/.tool-versions`), so you see a segment when your project pins a different version.
 
 #### `set -g theme_display_go verbose`
 
@@ -182,7 +184,7 @@ Use `no` to disable the Go version information. Set to `verbose` to show both th
 
 #### `set -g theme_display_node yes`
 
-This feature is disabled by default. Use `yes`, display the version if an `.nvmrc`, `.node-version` or `package.json` file is found in the parent path. Set to `always` to always display the current NPM, NVM or FNM node version.
+This feature is disabled by default. Use `yes`, display the version if an `.nvmrc`, `.node-version` or `package.json` file is found in the parent path. Set to `always` to always display the current NVM, FNM or asdf node version.
 
 #### `set -g theme_display_nix no`
 

--- a/functions/bobthefish_display_colors.fish
+++ b/functions/bobthefish_display_colors.fish
@@ -141,6 +141,10 @@ function bobthefish_display_colors -a color_scheme -d 'Print example prompt colo
   echo -ns $ruby_glyph nvm ' '
   __bobthefish_finish_segments
 
+  __bobthefish_start_segment $color_nvm
+  echo -ns $node_glyph asdf ' '
+  __bobthefish_finish_segments
+
   __bobthefish_start_segment $color_virtualfish
   echo -ns $virtualenv_glyph virtualfish ' '
   __bobthefish_finish_segments

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -913,12 +913,36 @@ function __bobthefish_virtualenv_python_version -S -d 'Get current Python versio
     end
 end
 
-function __bobthefish_prompt_virtualfish -S -d "Display current Python virtual environment (only for virtualfish, virtualenv's activate.fish changes prompt by itself) or conda environment."
+function __bobthefish_prompt_virtualfish -S -d "Display current Python virtual environment (only for virtualfish, virtualenv's activate.fish changes prompt by itself) or conda environment, or asdf-managed Python."
     command -q python
     or return
 
-    [ "$theme_display_virtualenv" = 'no' -o -z "$VIRTUAL_ENV" -a -z "$CONDA_DEFAULT_ENV" ]
+    [ "$theme_display_virtualenv" = 'no' ]
     and return
+
+    # When no virtualenv/conda, show asdf Python version if it's from a local .tool-versions
+    if [ -z "$VIRTUAL_ENV" -a -z "$CONDA_DEFAULT_ENV" ]
+        if command -q asdf
+            set -l asdf_current_python (asdf current python 2>/dev/null)
+            if [ -n "$asdf_current_python" ]
+                echo "$asdf_current_python" | read -l _asdf_plugin asdf_python_version asdf_provenance
+                set asdf_provenance (string trim -- "$asdf_provenance")
+                [ "$asdf_provenance" = "$HOME/.tool-versions" ]
+                and return
+
+                set -l version_glyph (__bobthefish_virtualenv_python_version)
+                __bobthefish_start_segment $color_virtualfish
+                if [ "$version_glyph" ]
+                    echo -ns $virtualenv_glyph $version_glyph ' '
+                else
+                    echo -ns $virtualenv_glyph
+                end
+                echo -ns $asdf_python_version ' '
+                return
+            end
+        end
+        return
+    end
 
     set -l version_glyph (__bobthefish_virtualenv_python_version)
     set -l prompt_style 'default'
@@ -1003,6 +1027,7 @@ function __bobthefish_prompt_node -S -d 'Display current node version'
 
     set -l node_manager
     set -l node_manager_dir
+    set -l node_version
 
     if type -q nvm
         set node_manager 'nvm'
@@ -1010,12 +1035,24 @@ function __bobthefish_prompt_node -S -d 'Display current node version'
     else if command -q fnm
         set node_manager 'fnm'
         set node_manager_dir $FNM_DIR
+    else if command -q asdf
+        set -l asdf_current_node (asdf current nodejs 2>/dev/null)
+        [ -z "$asdf_current_node" ]
+        and set asdf_current_node (asdf current node 2>/dev/null)
+        if [ -n "$asdf_current_node" ]
+            echo "$asdf_current_node" | read -l _asdf_plugin node_version asdf_provenance
+            set asdf_provenance (string trim -- "$asdf_provenance")
+            [ "$asdf_provenance" != "$HOME/.tool-versions" ]
+            and set node_manager 'asdf'
+        end
     end
 
-    [ -n "$node_manager_dir" ]
+    [ -n "$node_manager" ]
     or return
 
-    set -l node_version ("$node_manager" current 2> /dev/null)
+    if [ "$node_manager" != 'asdf' ]
+        set node_version ("$node_manager" current 2> /dev/null)
+    end
 
     [ -z $node_version -o "$node_version" = 'none' -o "$node_version" = 'system' ]
     and return


### PR DESCRIPTION
- Updated README.md to include asdf support for Ruby, Node.js, and Python versions.
- Modified fish_prompt.fish to display asdf-managed Python and Node.js versions when no virtualenv or conda environment is active.
- Adjusted bobthefish_display_colors.fish to include asdf in the color display for Node.js.