### PR TITLE
Add support for mise and refactor asdf version detection for Ruby and Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ This theme is based loosely on [agnoster][btf-agnoster].
      * Background jobs (**`%`**)
  * Current vi mode
  * `User@Host` (unless you're the default user)
- * Current RVM, rbenv or chruby (Ruby) version
+ * Current RVM, rbenv, chruby, asdf, or mise (Ruby) version
  * Current virtualenv (Python) version
      * _If you use virtualenv, you will probably need to disable the default virtualenv prompt, since it doesn't play nice with fish: `set -x VIRTUAL_ENV_DISABLE_PROMPT 1`_
- * Current NVM/FNM version (Nodejs) (inactive by default; see configurations in the next paragraph)
+ * Current NVM/FNM/asdf/mise version (Nodejs) (inactive by default; see configurations in the next paragraph)
  * Abbreviated parent directory
  * Current directory, or Git or Mercurial project name
  * Current project's repo branch (<img width="16" alt="branch-glyph" src="https://cloud.githubusercontent.com/assets/53660/8768360/53ee9b58-2e32-11e5-9977-cee0063936fa.png"> master) or detached head (`➦` d0dfd9b)
@@ -172,6 +172,10 @@ Use `no` to disable the current Docker machine name.
 
 Use `no` to disable Ruby version information. By default, the Ruby version is displayed unless it's your system Ruby version.
 
+#### `set -g theme_ruby_manager rbenv`
+
+If set, forces a specific Ruby version manager instead of probing. Valid values: `rvm`, `rbenv`, `chruby`, `asdf`, `mise`.
+
 #### `set -g theme_display_virtualenv no`
 
 Use `no` to disable Python version information. By default, the Python version is shown when it's interesting, along with the Virtualenv or Conda environmenmt.
@@ -183,6 +187,10 @@ Use `no` to disable the Go version information. Set to `verbose` to show both th
 #### `set -g theme_display_node yes`
 
 This feature is disabled by default. Use `yes`, display the version if an `.nvmrc`, `.node-version` or `package.json` file is found in the parent path. Set to `always` to always display the current NPM, NVM or FNM node version.
+
+#### `set -g theme_node_manager fnm`
+
+If set, forces a specific Node version manager instead of probing. Valid values: `nvm`, `fnm`, `asdf`, `mise`.
 
 #### `set -g theme_display_nix no`
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -800,8 +800,8 @@ function __bobthefish_rvm_info -S -d 'Current Ruby information from RVM'
     end
 end
 
-function __bobthefish_asdf_plugin_version -S -d 'Guess version of an executable managed by asdf'
-    set -l asdf_current_plugin (asdf current $argv[1] 2>/dev/null)
+function __bobthefish_asdf_plugin_version -S -a plugin -d 'Guess version of an executable managed by asdf'
+    set -l asdf_current_plugin (asdf current $plugin 2>/dev/null)
     or return
 
     echo "$asdf_current_plugin" | read -l _asdf_plugin asdf_plugin_version asdf_provenance
@@ -813,13 +813,13 @@ function __bobthefish_asdf_plugin_version -S -d 'Guess version of an executable 
     echo $asdf_plugin_version
 end
 
-function __bobthefish_mise_plugin_version -S -d 'Guess version of an executable managed by mise'
-    set -l mise_version (mise current $argv[1] 2>/dev/null)
+function __bobthefish_mise_plugin_version -S -a plugin -d 'Guess version of an executable managed by mise'
+    set -l mise_version (mise current $plugin 2>/dev/null)
     or return
 
     # mise outputs just the version number, unlike asdf which outputs "tool version source"
     # Only show if not from global config
-    set -l mise_source (mise ls --current $argv[1] 2>/dev/null | tail -n 1 | awk '{print $3}')
+    set -l mise_source (mise ls --current $plugin 2>/dev/null | tail -n 1 | awk '{print $3}')
     
     # Don't show if it's from the global config (expand ~ to $HOME for comparison)
     set -l global_config (string replace '~' "$HOME" "$mise_source")

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -834,9 +834,38 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
     and return
 
     set -l ruby_version
+
+    if set -q theme_ruby_manager
+        switch "$theme_ruby_manager"
+            case rvm
+                command -q rvm-prompt
+                and set ruby_version (__bobthefish_rvm_info)
+            case rbenv
+                command -q rbenv
+                and set ruby_version (rbenv version-name)
+            case chruby
+                type -q chruby
+                and set ruby_version $RUBY_VERSION
+            case asdf
+                type -fq asdf
+                and set ruby_version (__bobthefish_asdf_plugin_version ruby)
+            case mise
+                type -fq mise
+                and set ruby_version (__bobthefish_mise_plugin_version ruby)
+            case '*'
+                return
+        end
+
+        [ -z "$ruby_version" ]
+        and return
+    end
+
     if command -q rvm-prompt
         set ruby_version (__bobthefish_rvm_info)
-    else if command -q rbenv
+    end
+
+    if [ -z "$ruby_version" ]
+        and command -q rbenv
         set ruby_version (rbenv version-name)
         # Don't show global ruby version...
         set -q RBENV_ROOT
@@ -850,11 +879,20 @@ function __bobthefish_prompt_rubies -S -d 'Display current Ruby information'
 
         [ "$ruby_version" = "$global_ruby_version" ]
         and return
-    else if type -q chruby # chruby is implemented as a function, so using type -q is intentional
+    end
+
+    if [ -z "$ruby_version" ]
+        and type -q chruby # chruby is implemented as a function, so using type -q is intentional
         set ruby_version $RUBY_VERSION
-    else if type -fq asdf
+    end
+
+    if [ -z "$ruby_version" ]
+        and type -fq asdf
         set ruby_version (__bobthefish_asdf_plugin_version ruby)
-    else if type -fq mise
+    end
+
+    if [ -z "$ruby_version" ]
+        and type -fq mise
         set ruby_version (__bobthefish_mise_plugin_version ruby)
     end
 
@@ -1023,44 +1061,61 @@ function __bobthefish_prompt_node -S -d 'Display current node version'
     [ -z "$should_show" ]
     and return
 
-    set -l node_manager
-    set -l node_manager_dir
-
-    if type -q nvm
-      set node_manager 'nvm'
-      set node_manager_dir $NVM_DIR
-    else if type -fq fnm
-      set node_manager 'fnm'
-      set node_manager_dir $FNM_DIR
-    else if type -fq asdf
-      set node_manager 'asdf'
-      set node_manager_dir $ASDF_DIR
-    else if type -fq mise
-      set node_manager 'mise'
-      set node_manager_dir ~/.config/mise/
-    end
-
-    [ -n "$node_manager_dir" ]
-    or return
-
     set -l node_version
 
-    if [ "$node_manager" = 'asdf' ]
-        set node_version (__bobthefish_asdf_plugin_version nodejs)
+    if set -q theme_node_manager
+        switch "$theme_node_manager"
+            case nvm
+                type -q nvm
+                and set node_version (nvm current 2> /dev/null)
+            case fnm
+                type -fq fnm
+                and set node_version (fnm current 2> /dev/null)
+            case asdf
+                type -fq asdf
+                and set node_version (__bobthefish_asdf_plugin_version nodejs)
+            case mise
+                type -fq mise
+                and set node_version (__bobthefish_mise_plugin_version nodejs)
+            case '*'
+                return
+        end
 
-        [ -z $node_version ]
-        and return
-    else if [ "$node_manager" = 'mise' ]
-        set node_version (__bobthefish_mise_plugin_version nodejs)
+        if [ "$node_version" = 'none' -o "$node_version" = 'system' ]
+            set -e node_version
+        end
 
-        [ -z $node_version ]
-        and return
-    else
-        set node_version ("$node_manager" current 2> /dev/null)
-
-        [ -z $node_version -o "$node_version" = 'none' -o "$node_version" = 'system' ]
+        [ -z "$node_version" ]
         and return
     end
+
+    if type -q nvm
+        set node_version (nvm current 2> /dev/null)
+        if [ -z "$node_version" -o "$node_version" = 'none' -o "$node_version" = 'system' ]
+            set -e node_version
+        end
+    end
+
+    if [ -z "$node_version" ]
+        and type -fq fnm
+        set node_version (fnm current 2> /dev/null)
+        if [ -z "$node_version" -o "$node_version" = 'none' -o "$node_version" = 'system' ]
+            set -e node_version
+        end
+    end
+
+    if [ -z "$node_version" ]
+        and type -fq asdf
+        set node_version (__bobthefish_asdf_plugin_version nodejs)
+    end
+
+    if [ -z "$node_version" ]
+        and type -fq mise
+        set node_version (__bobthefish_mise_plugin_version nodejs)
+    end
+
+    [ -z "$node_version" ]
+    and return
 
     [ -n "$color_nvm" ]
     and set -x color_node $color_nvm


### PR DESCRIPTION
This PR introduces support for the [mise](https://mise.jdx.dev/) version manager and refactors the existing asdf logic into reusable helper functions to reduce code duplication.

Changes:

- New Helper Functions:
  - `__bobthefish_asdf_plugin_version`: Extracted the asdf parsing logic that was previously inline. It ensures we continue to ignore versions set in `$HOME/.tool-versions` (global).
  - `__bobthefish_mise_plugin_version`: specific logic for mise. It parses mise `ls --current` to check the source of the version and ignores it if it comes from the global config (`~/.config/mise/config.toml`), matching the theme's existing behavior for other managers.
- Ruby Prompt:
  - Updated to use the new asdf helper.
  - Added detection for mise.
- Node Prompt:
  - Added asdf and mise to the manager detection list.
  - Refactored the version retrieval logic to handle the specific requirements of asdf/mise (via helpers) vs nvm/fnm (via current command).