### PR TITLE
Resolve broken Golang version display when go.mod includes CRLF line endings

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -853,7 +853,7 @@ function __bobthefish_prompt_golang -S -a real_pwd -d 'Display current Go inform
     set -l d $real_pwd
     while not [ -z "$d" ]
         if [ -e $d/go.mod ]
-            grep "^go " "$d/go.mod" | sed 's/\r//' | read __ gomod_version
+            string match -rq '^go\s(?<gomod_version>\S+)' < "$d/go.mod"
             break
         end
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -853,7 +853,7 @@ function __bobthefish_prompt_golang -S -a real_pwd -d 'Display current Go inform
     set -l d $real_pwd
     while not [ -z "$d" ]
         if [ -e $d/go.mod ]
-            grep "^go " "$d/go.mod" | read __ gomod_version
+            grep "^go " "$d/go.mod" | sed 's/\r//' | read __ gomod_version
             break
         end
 


### PR DESCRIPTION
This PR resolves a very corner-case issue where the prompt does not display the Go version if the go.mod file contains CRLF line endings. I ran into this issue with a project originally created on a Windows box. For some reason in this project, Git properly converted the line endings in all .go source files, but not in the go.mod file. This caused the prompt to display a red go glyph and no version information.

Converting the line endings resolved the issue, but there may be people who need to work on projects in a Windows file system or in some other situation where converting line endings is not feasible. To solve for those corner cases, I've replaced the grep pipeline with bobthecow's recommended `string replace` call, below.
